### PR TITLE
Add SUMP mode autodetection

### DIFF
--- a/hydrabus/hydrabus_sump.c
+++ b/hydrabus/hydrabus_sump.c
@@ -153,8 +153,19 @@ static void sump_deinit(void)
 	}
 }
 
-int cmd_sump(t_hydra_console *con, __attribute__((unused)) t_tokenline_parsed *p) __attribute__((optimize("-O3")));
-int cmd_sump(t_hydra_console *con, __attribute__((unused)) t_tokenline_parsed *p)
+int cmd_sump(t_hydra_console *con, t_tokenline_parsed *p)
+{
+	(void) p;
+	cprintf(con, "Interrupt by pressing user button.\r\n");
+	cprint(con, "\r\n", 2);
+
+	sump(con);
+
+	return TRUE;
+}
+
+void sump(t_hydra_console *con) __attribute__((optimize("-O3")));
+void sump(t_hydra_console *con)
 {
 
 	sump_init();
@@ -163,9 +174,6 @@ int cmd_sump(t_hydra_console *con, __attribute__((unused)) t_tokenline_parsed *p
 	uint8_t sump_command;
 	uint8_t sump_parameters[4] = {0};
 	uint32_t index=0;
-
-	cprintf(con, "Interrupt by pressing user button.\r\n");
-	cprint(con, "\r\n", 2);
 
 	while (!palReadPad(GPIOA, 0)) {
 		if(chnReadTimeout(con->sdu, &sump_command, 1, 1)) {
@@ -296,6 +304,5 @@ int cmd_sump(t_hydra_console *con, __attribute__((unused)) t_tokenline_parsed *p
 		}
 	}
 	sump_deinit();
-	return TRUE;
 }
 

--- a/hydrabus/hydrabus_sump.h
+++ b/hydrabus/hydrabus_sump.h
@@ -48,3 +48,4 @@ typedef struct {
 	uint8_t state;
 	uint8_t channels;
 } sump_config;
+void sump(t_hydra_console *con);


### PR DESCRIPTION
This patch adds the possibility to automatically switch to SUMP mode
when Hydrabus is polled by a SUMP client (tested with OLS client and
Sigrok).