### PR TITLE
Hexdump feature refactor

### DIFF
--- a/hydrabus/hydrabus_mode.h
+++ b/hydrabus/hydrabus_mode.h
@@ -65,6 +65,8 @@ typedef struct mode_exec_t {
 	uint32_t (*write)(t_hydra_console *con, uint8_t *tx_data, uint8_t nb_data);
 	/* Read data command 'read' or 'read:n' (return status 0=OK) */
 	uint32_t (*read)(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
+	/* Dump data */
+	uint32_t (*dump)(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
 	/* Write & Read data (return status 0=OK) */
 	uint32_t (*write_read)(t_hydra_console *con, uint8_t *tx_data, uint8_t *rx_data, uint8_t nb_data);
 	/* Set CLK High (x-WIRE or other raw mode) command '/' */

--- a/hydrabus/hydrabus_mode_onewire.c
+++ b/hydrabus/hydrabus_mode_onewire.c
@@ -27,7 +27,6 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data);
 
 static const char* str_prompt_onewire[] = {
 	"onewire1" PROMPT,
@@ -266,7 +265,6 @@ static int init(t_hydra_console *con, t_tokenline_parsed *p)
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
-	uint32_t arg_u32;
 	int t;
 
 	for (t = token_pos; p->tokens[t]; t++) {
@@ -287,16 +285,6 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 				break;
 			}
 			onewire_pin_init(con);
-			break;
-		case T_HD:
-			/* Integer parameter. */
-			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
-				t += 2;
-				memcpy(&arg_u32, p->buf + p->tokens[t], sizeof(uint32_t));
-			} else {
-				arg_u32 = 1;
-			}
-			dump(con, proto->buffer_rx, arg_u32);
 			break;
 		case T_MSB_FIRST:
 			proto->dev_bit_lsb_msb = DEV_SPI_FIRSTBIT_MSB;
@@ -358,25 +346,13 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 {
-	uint32_t bytes_read = 0;
-	uint8_t i, to_rx;
+	uint8_t i;
 
-	while(bytes_read < nb_data){
-		/* using 240 to stay aligned in hexdump */
-		if((nb_data-bytes_read) >= 240) {
-			to_rx = 240;
-		} else {
-			to_rx = (nb_data-bytes_read);
-		}
-
-		for(i = 0; i < to_rx; i++) {
-			rx_data[i] = onewire_read_u8(con);
-		}
-		print_hex(con, rx_data, to_rx);
-
-		bytes_read += to_rx;
+	while(i < nb_data){
+		rx_data[i] = onewire_read_u8(con);
+		i++;
 	}
 	return BSP_OK;
 }
@@ -411,6 +387,7 @@ const mode_exec_t mode_onewire_exec = {
 	.exec = &exec,
 	.write = &write,
 	.read = &read,
+	.dump = &dump,
 	.cleanup = &onewire_cleanup,
 	.get_prompt = &get_prompt,
 	.dath = &dath,

--- a/hydrabus/hydrabus_mode_spi.c
+++ b/hydrabus/hydrabus_mode_spi.c
@@ -25,7 +25,6 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data);
 
 static const char* str_pins_spi1= {
 	"CS:   PA15\r\nSCK:  PB3\r\nMISO: PB4\r\nMOSI: PB5\r\n"
@@ -130,7 +129,6 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
 	float arg_float;
-	uint32_t arg_u32;
 	int arg_int, t, i;
 	bsp_status_t bsp_status;
 
@@ -246,16 +244,6 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 				return t;
 			}
 			break;
-		case T_HD:
-			/* Integer parameter. */
-			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
-				t += 2;
-				memcpy(&arg_u32, p->buf + p->tokens[t], sizeof(uint32_t));
-			} else {
-				arg_u32 = 1;
-			}
-			dump(con, proto->buffer_rx, arg_u32);
-			break;
 		default:
 			return t - token_pos;
 		}
@@ -326,28 +314,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return status;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 {
 	uint32_t status;
-	uint32_t bytes_read = 0;
-	uint8_t to_rx;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	while(bytes_read < nb_data){
-		/* using 240 to stay aligned in hexdump */
-		if((nb_data-bytes_read) >= 240) {
-			to_rx = 240;
-		} else {
-			to_rx = (nb_data-bytes_read);
-		}
-
-		status = bsp_spi_read_u8(proto->dev_num, rx_data, to_rx);
-		if (status == BSP_OK) {
-			print_hex(con, rx_data, to_rx);
-		}
-
-		bytes_read += to_rx;
-	}
+	status = bsp_spi_read_u8(proto->dev_num, rx_data, nb_data);
 	return status;
 }
 
@@ -415,6 +387,7 @@ const mode_exec_t mode_spi_exec = {
 	.stop = &stop,
 	.write = &write,
 	.read = &read,
+	.dump = &dump,
 	.write_read = &write_read,
 	.cleanup = &cleanup,
 	.get_prompt = &get_prompt,

--- a/hydrabus/hydrabus_mode_threewire.c
+++ b/hydrabus/hydrabus_mode_threewire.c
@@ -27,7 +27,6 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data);
 
 static threewire_config config;
 static TIM_HandleTypeDef htim;
@@ -265,7 +264,6 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
 	float arg_float;
-	uint32_t arg_u32;
 	int t;
 
 	for (t = token_pos; p->tokens[t]; t++) {
@@ -302,16 +300,6 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 				proto->dev_speed = (int)arg_float;
 				threewire_tim_set_prescaler(con);
 			}
-			break;
-		case T_HD:
-			/* Integer parameter. */
-			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
-				t += 2;
-				memcpy(&arg_u32, p->buf + p->tokens[t], sizeof(uint32_t));
-			} else {
-				arg_u32 = 1;
-			}
-			dump(con, proto->buffer_rx, arg_u32);
 			break;
 		default:
 			return t - token_pos;
@@ -364,25 +352,13 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint32_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 {
-	uint32_t bytes_read = 0;
-	uint8_t i, to_rx;
+	uint8_t i;
 
-	while(bytes_read < nb_data){
-		/* using 240 to stay aligned in hexdump */
-		if((nb_data-bytes_read) >= 240) {
-			to_rx = 240;
-		} else {
-			to_rx = (nb_data-bytes_read);
-		}
-
-		for(i = 0; i < to_rx; i++) {
-			rx_data[i] = threewire_read_u8(con);
-		}
-		print_hex(con, rx_data, to_rx);
-
-		bytes_read += to_rx;
+	while(i < nb_data){
+		rx_data[i] = threewire_read_u8(con);
+		i++;
 	}
 	return BSP_OK;
 }
@@ -419,6 +395,7 @@ const mode_exec_t mode_threewire_exec = {
 	.exec = &exec,
 	.write = &write,
 	.read = &read,
+	.dump = &dump,
 	.cleanup = &threewire_cleanup,
 	.get_prompt = &get_prompt,
 	.clkl = &clkl,

--- a/hydrabus/hydrabus_mode_uart.c
+++ b/hydrabus/hydrabus_mode_uart.c
@@ -25,7 +25,6 @@
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
 
 static const char* str_pins_uart[] = {
 	"TX: PA9\r\nRX: PA10\r\n",
@@ -224,16 +223,6 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 		case T_BRIDGE:
 			bridge(con);
 			break;
-		case T_HD:
-			/* Integer parameter. */
-			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
-				t += 2;
-				memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
-			} else {
-				arg_int = 1;
-			}
-			dump(con, proto->buffer_rx, arg_int);
-			break;
 		default:
 			return t - token_pos;
 		}
@@ -294,9 +283,7 @@ static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	mode_config_proto_t* proto = &con->mode->proto;
 
 	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data);
-	if(status == BSP_OK) {
-		print_hex(con, rx_data, nb_data);
-	}
+
 	return status;
 }
 
@@ -356,6 +343,7 @@ const mode_exec_t mode_uart_exec = {
 	.exec = &exec,
 	.write = &write,
 	.read = &read,
+	.dump = &dump,
 	.write_read = &write_read,
 	.cleanup = &cleanup,
 	.get_prompt = &get_prompt,


### PR DESCRIPTION
This patch refactors the hexdump feature.
 * `hd` command is handled in `cmd_mode_exec` and common in all modes
 * The `dump` function in all modes is now a read with no console output
 * New member of structure `mode_exec_t` maps the `dump` function