### PR TITLE
[WIP] Add SLCAN support for CAN mode

### DIFF
--- a/drv/stm32cube/bsp_can.c
+++ b/drv/stm32cube/bsp_can.c
@@ -329,6 +329,24 @@ bsp_status_t bsp_can_write(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg)
 }
 
 /**
+  * @brief  Sends a message in non blocking mode
+  * @param  dev_num: CAN dev num.
+  * @param  tx_msg: Message to send
+  * @retval status of the transfer. Always BSP_OK
+  */
+bsp_status_t bsp_can_put(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg)
+{
+	CAN_HandleTypeDef* hcan;
+
+	hcan = &can_handle[dev_num];
+
+	hcan->pTxMsg = tx_msg;
+
+	HAL_CAN_Transmit(hcan, 1);
+	return BSP_OK;
+}
+
+/**
   * @brief  Read a message in blocking mode and return the status.
   * @param  dev_num: CAN dev num.
   * @param  rx_msg: Message to receive.

--- a/drv/stm32cube/bsp_can.c
+++ b/drv/stm32cube/bsp_can.c
@@ -378,13 +378,20 @@ bsp_status_t bsp_can_write(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg)
 bsp_status_t bsp_can_put(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg)
 {
 	CAN_HandleTypeDef* hcan;
+	bsp_status_t status;
 
 	hcan = &can_handle[dev_num];
 
 	hcan->pTxMsg = tx_msg;
 
-	HAL_CAN_Transmit(hcan, 1);
-	return BSP_OK;
+	status = HAL_CAN_Transmit(hcan, 10);
+	switch(status){
+	case BSP_OK:
+	case BSP_TIMEOUT:
+		return BSP_OK;
+	default:
+		return BSP_ERROR;
+	}
 }
 
 /**

--- a/drv/stm32cube/bsp_can.c
+++ b/drv/stm32cube/bsp_can.c
@@ -242,7 +242,7 @@ bsp_status_t bsp_can_mode_rw(bsp_dev_can_t dev_num, mode_config_proto_t* mode_co
 	HAL_CAN_DeInit(hcan);
 
 	mode_conf->dev_mode = BSP_CAN_MODE_RW;
-	hcan->Init.Mode = CAN_MODE_LOOPBACK;
+	hcan->Init.Mode = CAN_MODE_NORMAL;
 
 	status = HAL_CAN_Init(hcan);
 
@@ -299,7 +299,7 @@ bsp_status_t bsp_can_init(bsp_dev_can_t dev_num, mode_config_proto_t* mode_conf)
 	if(mode_conf->dev_mode == BSP_CAN_MODE_RO) {
 		hcan->Init.Mode = CAN_MODE_SILENT;
 	} else {
-		hcan->Init.Mode = CAN_MODE_LOOPBACK;
+		hcan->Init.Mode = CAN_MODE_NORMAL;
 	}
 
 	/* CAN timing values */

--- a/drv/stm32cube/bsp_can.c
+++ b/drv/stm32cube/bsp_can.c
@@ -165,9 +165,9 @@ bsp_status_t bsp_can_set_timings(bsp_dev_can_t dev_num, uint8_t ts1, uint8_t ts2
 
 	HAL_CAN_DeInit(hcan);
 
-	hcan->Init.SJW = (uint32_t)sjw<<24;
-	hcan->Init.BS1 = (uint32_t)ts1<<16;
-	hcan->Init.BS2 = (uint32_t)ts2<<20;
+	hcan->Init.BS1 = (uint32_t)(ts1-1)<<16;
+	hcan->Init.BS2 = (uint32_t)(ts2-1)<<20;
+	hcan->Init.SJW = (uint32_t)(sjw-1)<<24;
 
 	status = HAL_CAN_Init(hcan);
 

--- a/drv/stm32cube/bsp_can.h
+++ b/drv/stm32cube/bsp_can.h
@@ -34,7 +34,10 @@ bsp_status_t bsp_can_set_filter(bsp_dev_can_t dev_num, mode_config_proto_t* mode
 bsp_status_t bsp_can_deinit(bsp_dev_can_t dev_num);
 bsp_status_t bsp_can_write(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg);
 bsp_status_t bsp_can_read(bsp_dev_can_t dev_num, CanRxMsgTypeDef* rx_msg);
+bsp_status_t bsp_can_put(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg);
 
 bsp_status_t bsp_can_rxne(bsp_dev_can_t dev_num);
+uint32_t bsp_can_get_timings(bsp_dev_can_t dev_num);
+bsp_status_t bsp_can_set_timings(bsp_dev_can_t dev_num, uint8_t ts1, uint8_t ts2, uint8_t sjw);
 
 #endif /* _BSP_CAN_H_ */

--- a/drv/stm32cube/bsp_can.h
+++ b/drv/stm32cube/bsp_can.h
@@ -20,6 +20,9 @@ limitations under the License.
 #include "mode_config.h"
 #include "stm32f4xx_hal.h"
 
+#define BSP_CAN_MODE_RO	0
+#define BSP_CAN_MODE_RW	1
+
 typedef enum {
 	BSP_DEV_CAN1 = 0,
 	BSP_DEV_CAN2 = 1,
@@ -38,6 +41,11 @@ bsp_status_t bsp_can_put(bsp_dev_can_t dev_num, CanTxMsgTypeDef* tx_msg);
 
 bsp_status_t bsp_can_rxne(bsp_dev_can_t dev_num);
 uint32_t bsp_can_get_timings(bsp_dev_can_t dev_num);
-bsp_status_t bsp_can_set_timings(bsp_dev_can_t dev_num, uint8_t ts1, uint8_t ts2, uint8_t sjw);
+bsp_status_t bsp_can_set_timings(bsp_dev_can_t dev_num, mode_config_proto_t* mode_conf);
+bsp_status_t bsp_can_set_ts1(bsp_dev_can_t dev_num, mode_config_proto_t* mode_conf, uint8_t ts1);
+bsp_status_t bsp_can_set_ts2(bsp_dev_can_t dev_num, mode_config_proto_t* mode_conf, uint8_t ts2);
+bsp_status_t bsp_can_set_sjw(bsp_dev_can_t dev_num, mode_config_proto_t* mode_conf, uint8_t sjw);
+bsp_status_t bsp_can_mode_rw(bsp_dev_can_t dev_num, mode_config_proto_t* mode_conf);
+
 
 #endif /* _BSP_CAN_H_ */

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -147,6 +147,7 @@ t_token_dict tl_dict[] = {
 	{ T_ONEWIRE, "1-wire" },
 	{ T_FLASH, "flash" },
 	{ T_TRIGGER, "trigger" },
+	{ T_SLCAN, "slcan" },
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */
@@ -559,6 +560,10 @@ t_token tokens_mode_can[] = {
 		T_TILDE,
 		.flags = T_FLAG_SUFFIX_TOKEN_DELIM_INT,
 		.help = "Write a random byte (repeat with :<num>)"
+	},
+	{
+		T_SLCAN,
+		.help = "slcan (LAWICEL) mode"
 	},
 	{
 		T_EXIT,

--- a/hydrabus/commands.c
+++ b/hydrabus/commands.c
@@ -148,6 +148,9 @@ t_token_dict tl_dict[] = {
 	{ T_FLASH, "flash" },
 	{ T_TRIGGER, "trigger" },
 	{ T_SLCAN, "slcan" },
+	{ T_TS1, "ts1" },
+	{ T_TS2, "ts2" },
+	{ T_SJW, "sjw" },
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */
@@ -511,6 +514,21 @@ t_token tokens_uart[] = {
 		T_SPEED,\
 		.arg_type = T_ARG_UINT,\
 		.help = "Bus bitrate"\
+	},\
+	{\
+		T_TS1,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Time segment 1 value (1-16)"\
+	},\
+	{\
+		T_TS2,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Time segment 2 value (1-8)"\
+	},\
+	{\
+		T_SJW,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Resynchronisation jump width (1-4)"\
 	},
 
 t_token tokens_mode_can[] = {

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -139,6 +139,7 @@ enum {
 	T_ONEWIRE,
 	T_FLASH,
 	T_TRIGGER,
+	T_SLCAN,
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */

--- a/hydrabus/commands.h
+++ b/hydrabus/commands.h
@@ -140,6 +140,9 @@ enum {
 	T_FLASH,
 	T_TRIGGER,
 	T_SLCAN,
+	T_TS1,
+	T_TS2,
+	T_SJW,
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */

--- a/hydrabus/hydrabus_bbio.h
+++ b/hydrabus/hydrabus_bbio.h
@@ -87,6 +87,7 @@
 #define BBIO_CAN_FILTER		0b00000110
 #define BBIO_CAN_WRITE		0b00001000
 #define BBIO_CAN_SET_SPEED	0b01100000
+#define BBIO_CAN_SLCAN		0b10100000
 
 /*
  * PIN control-specific commands

--- a/hydrabus/hydrabus_bbio_can.c
+++ b/hydrabus/hydrabus_bbio_can.c
@@ -24,6 +24,7 @@
 #include <string.h>
 #include <ctype.h>
 
+#include "hydrabus_mode_can.h"
 #include "hydrabus_bbio.h"
 #include "hydrabus_bbio_can.h"
 #include "bsp_can.h"
@@ -112,6 +113,9 @@ void bbio_mode_can(t_hydra_console *con)
 				}else{
 					cprint(con, "\x00", 1);
 				}
+				break;
+			case BBIO_CAN_SLCAN:
+				slcan(con);
 				break;
 			default:
 				if ((bbio_subcommand & BBIO_CAN_WRITE) == BBIO_CAN_WRITE) {

--- a/hydrabus/hydrabus_mode_can.c
+++ b/hydrabus/hydrabus_mode_can.c
@@ -224,7 +224,7 @@ void slcan(t_hydra_console *con) {
 			}
 
 			if(bsp_can_set_speed(proto->dev_num, proto->dev_speed) == BSP_OK) {
-				cprint(con, "\n", 1);
+				cprint(con, "\r", 1);
 			}else {
 				cprint(con, "\x07", 1);
 			}
@@ -288,11 +288,11 @@ void slcan(t_hydra_console *con) {
 			break;
 		case 'V':
 			/*Version*/
-			cprint(con, "V0101\n", 6);
+			cprint(con, "V0101\r", 6);
 			break;
 		case 'N':
 			/*Serial*/
-			cprint(con, "NHYDR\n", 6);
+			cprint(con, "NHYDR\r", 6);
 			break;
 		case 'Z':
 			/*Timestamp*/

--- a/hydrabus/hydrabus_mode_can.c
+++ b/hydrabus/hydrabus_mode_can.c
@@ -318,6 +318,11 @@ static int init(t_hydra_console *con, t_tokenline_parsed *p)
 	config[proto->dev_num].ts2 = 4;
 	config[proto->dev_num].sjw = 3;
 
+	bsp_can_set_timings(proto->dev_num,
+			    config[proto->dev_num].ts1,
+			    config[proto->dev_num].ts2,
+			    config[proto->dev_num].sjw);
+
 	/* Process cmdline arguments, skipping "can". */
 	tokens_used = 1 + exec(con, p, 1);
 
@@ -388,7 +393,7 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			t += 2;
 			memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
 			if(arg_int > 0 && arg_int <= 16) {
-				config[proto->dev_num].ts1 = arg_int-1;
+				config[proto->dev_num].ts1 = arg_int;
 				bsp_status = bsp_can_set_timings(proto->dev_num,
 								 config[proto->dev_num].ts1,
 								 config[proto->dev_num].ts2,
@@ -406,7 +411,7 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			t += 2;
 			memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
 			if(arg_int > 0 && arg_int <= 8) {
-				config[proto->dev_num].ts2 = arg_int-1;
+				config[proto->dev_num].ts2 = arg_int;
 				bsp_status = bsp_can_set_timings(proto->dev_num,
 								 config[proto->dev_num].ts1,
 								 config[proto->dev_num].ts2,
@@ -424,7 +429,7 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			t += 2;
 			memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
 			if(arg_int > 0 && arg_int <= 4) {
-				config[proto->dev_num].sjw = arg_int-1;
+				config[proto->dev_num].sjw = arg_int;
 				bsp_status = bsp_can_set_timings(proto->dev_num,
 								 config[proto->dev_num].ts1,
 								 config[proto->dev_num].ts2,

--- a/hydrabus/hydrabus_mode_can.c
+++ b/hydrabus/hydrabus_mode_can.c
@@ -299,6 +299,9 @@ void slcan(t_hydra_console *con) {
 			/*Not implemented*/
 			cprint(con, "\x07", 1);
 			break;
+		default:
+			cprint(con, "\x07", 1);
+			break;
 		}
 	}
 	chThdTerminate(rthread);

--- a/hydrabus/hydrabus_mode_can.c
+++ b/hydrabus/hydrabus_mode_can.c
@@ -172,7 +172,7 @@ msg_t can_reader_thread (void *arg)
 	CanRxMsgTypeDef rx_msg;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	while (!USER_BUTTON && !chThdShouldTerminateX()) {
+	while (!chThdShouldTerminateX()) {
 		if(bsp_can_rxne(proto->dev_num)) {
 			chSysLock();
 			bsp_can_read(proto->dev_num, &rx_msg);
@@ -260,13 +260,9 @@ void slcan(t_hydra_console *con) {
 			if(rthread != NULL) {
 				chThdTerminate(rthread);
 				chThdWait(rthread);
+				rthread = NULL;
 			}
-			rthread = NULL;
-			if(bsp_can_deinit(proto->dev_num) == BSP_OK) {
-				cprint(con, "\r", 1);
-			}else {
-				cprint(con, "\x07", 1);
-			}
+			cprint(con, "\r", 1);
 			break;
 		case 't':
 		case 'T':
@@ -312,8 +308,11 @@ void slcan(t_hydra_console *con) {
 			break;
 		}
 	}
-	chThdTerminate(rthread);
-	chThdWait(rthread);
+	if(rthread != NULL) {
+		chThdTerminate(rthread);
+		chThdWait(rthread);
+		rthread = NULL;
+	}
 }
 
 static int init(t_hydra_console *con, t_tokenline_parsed *p)

--- a/hydrabus/hydrabus_mode_can.h
+++ b/hydrabus/hydrabus_mode_can.h
@@ -30,9 +30,6 @@ typedef struct {
 	uint32_t can_id;
 	uint32_t filter_id_low;
 	uint32_t filter_id_high;
-	uint8_t ts1;
-	uint8_t ts2;
-	uint8_t sjw;
 } can_config;
 
 void slcan(t_hydra_console *con);

--- a/hydrabus/hydrabus_mode_can.h
+++ b/hydrabus/hydrabus_mode_can.h
@@ -30,6 +30,9 @@ typedef struct {
 	uint32_t can_id;
 	uint32_t filter_id_low;
 	uint32_t filter_id_high;
+	uint8_t ts1;
+	uint8_t ts2;
+	uint8_t sjw;
 } can_config;
 
 void slcan(t_hydra_console *con);

--- a/hydrabus/hydrabus_mode_can.h
+++ b/hydrabus/hydrabus_mode_can.h
@@ -24,9 +24,12 @@
 
 #endif /* _HYDRABUS_MODE_CAN_H_ */
 
+#define SLCAN_BUFF_LEN 50
+
 typedef struct {
 	uint32_t can_id;
 	uint32_t filter_id_low;
 	uint32_t filter_id_high;
 } can_config;
 
+void slcan(t_hydra_console *con);


### PR DESCRIPTION
This PR adds the LAWICEL/SLCAN protocol in the CAN mode. 
It allows to use the Linux `can-utils` tools to ease the CAN bus analysis