### PR TITLE
GCC 8.1 fixes

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -17,7 +17,7 @@ endif
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -Os -ggdb -fomit-frame-pointer -falign-functions=16
+  USE_OPT = -Os -ggdb -fomit-frame-pointer -falign-functions=16 -std=gnu89
 endif
 
 # C specific options here (added to USE_OPT).

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,6 +8,7 @@ MAKEFLAGS += --no-builtin-rules
 
 #Set to 1 HYDRAFW_NFC to include HydraNFC extension support
 export HYDRAFW_NFC ?= 1
+export HYDRAFW_DEBUG ?= 0
 
 HYDRAFW_OPTS =
 
@@ -17,8 +18,14 @@ endif
 
 # Compiler options here.
 ifeq ($(USE_OPT),)
-  USE_OPT = -Os -ggdb -fomit-frame-pointer -falign-functions=16 -std=gnu89
+  USE_OPT = -Os -fomit-frame-pointer -falign-functions=16 -std=gnu89
 endif
+
+ifeq ($(HYDRAFW_DEBUG),1)
+  USE_OPT += -ggdb
+  USE_LTO = no
+endif
+
 
 # C specific options here (added to USE_OPT).
 ifeq ($(USE_COPT),)

--- a/src/common/microsd.c
+++ b/src/common/microsd.c
@@ -94,6 +94,9 @@ bool file_open(FIL *file_handle, const char * filename, const char mode)
 	case 'a':
 		flags = FA_WRITE | FA_OPEN_EXISTING;
 		break;
+	default:
+		flags = FA_READ | FA_OPEN_EXISTING;
+		break;
 	}
 
 	if (f_open(file_handle, (TCHAR *)filename, flags) != FR_OK) {

--- a/src/drv/stm32cube/bsp_can.c
+++ b/src/drv/stm32cube/bsp_can.c
@@ -469,6 +469,7 @@ bsp_status_t bsp_can_read(bsp_dev_can_t dev_num, can_rx_frame* rx_msg)
 
 	hcan = &can_handle[dev_num];
 
+	start_time = HAL_GetTick();
 	while(HAL_CAN_GetRxFifoFillLevel(hcan, CAN_RX_FIFO0) == 0) {
 		if((HAL_GetTick()-start_time) > CANx_TIMEOUT_MAX) {
 			return BSP_TIMEOUT;

--- a/src/drv/stm32cube/bsp_i2c.c
+++ b/src/drv/stm32cube/bsp_i2c.c
@@ -12,10 +12,10 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-#include "bsp_i2c.h"
-#include "bsp_i2c_conf.h"
 #include "stm32f405xx.h"
 #include "stm32f4xx_hal.h"
+#include "bsp_i2c.h"
+#include "bsp_i2c_conf.h"
 
 #define BSP_I2C_DELAY_HC_50KHZ   (1680) /* 50KHz*2 (Half Clock) in number of cycles @168MHz */
 #define BSP_I2C_DELAY_HC_100KHZ  (840) /* 100KHz*2 (Half Clock) in number of cycles @168MHz */

--- a/src/drv/stm32cube/bsp_i2c.c
+++ b/src/drv/stm32cube/bsp_i2c.c
@@ -202,7 +202,7 @@ bsp_status_t bsp_i2c_stop(bsp_dev_i2c_t dev_num)
  * \return bsp_status_t: status of the transfer.
  *
  */
-bsp_status_t bsp_i2c_master_write_u8(bsp_dev_i2c_t dev_num, uint8_t tx_data, bool* tx_ack_flag)
+bsp_status_t bsp_i2c_master_write_u8(bsp_dev_i2c_t dev_num, uint8_t tx_data, uint8_t* tx_ack_flag)
 {
 	(void)dev_num;
 	int i;

--- a/src/drv/stm32cube/bsp_i2c.h
+++ b/src/drv/stm32cube/bsp_i2c.h
@@ -28,7 +28,7 @@ bsp_status_t bsp_i2c_deinit(bsp_dev_i2c_t dev_num);
 bsp_status_t bsp_i2c_start(bsp_dev_i2c_t dev_num);
 bsp_status_t bsp_i2c_stop(bsp_dev_i2c_t dev_num);
 
-bsp_status_t bsp_i2c_master_write_u8(bsp_dev_i2c_t dev_num, uint8_t tx_data, bool* tx_ack_flag);
+bsp_status_t bsp_i2c_master_write_u8(bsp_dev_i2c_t dev_num, uint8_t tx_data, uint8_t* tx_ack_flag);
 bsp_status_t bsp_i2c_master_read_u8(bsp_dev_i2c_t dev_num, uint8_t* rx_data);
 void bsp_i2c_read_ack(bsp_dev_i2c_t dev_num, bool enable_ack);
 

--- a/src/hydrabus/hydrabus_bbio_i2c.c
+++ b/src/hydrabus/hydrabus_bbio_i2c.c
@@ -59,7 +59,7 @@ void bbio_mode_i2c(t_hydra_console *con)
 	uint8_t *tx_data = (uint8_t *)g_sbuf;
 	uint8_t *rx_data = (uint8_t *)g_sbuf+4096;
 	uint8_t data;
-	bool tx_ack_flag;
+	uint8_t tx_ack_flag;
 	bsp_status_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 

--- a/src/hydrabus/hydrabus_bbio_onewire.c
+++ b/src/hydrabus/hydrabus_bbio_onewire.c
@@ -55,6 +55,7 @@ void bbio_mode_onewire(t_hydra_console *con)
 				break;
 			case BBIO_ONEWIRE_RESET:
 				onewire_start(con);
+				break;
 			case BBIO_ONEWIRE_READ:
 				rx_data[0] = onewire_read_u8(con);
 				cprint(con, (char *)&rx_data[0], 1);

--- a/src/hydrabus/hydrabus_bbio_uart.c
+++ b/src/hydrabus/hydrabus_bbio_uart.c
@@ -39,7 +39,7 @@ void bbio_uart_init_proto_default(t_hydra_console *con)
 	proto->config.uart.dev_stop_bit = 1;
 }
 
-msg_t uart_reader_thread (void *arg)
+static THD_FUNCTION(uart_reader_thread, arg)
 {
 	t_hydra_console *con;
 	con = arg;
@@ -58,7 +58,6 @@ msg_t uart_reader_thread (void *arg)
 		}
 	}
 	chThdExit((msg_t)1);
-	return (msg_t)1;
 }
 
 static void bbio_mode_id(t_hydra_console *con)
@@ -94,7 +93,7 @@ void bbio_mode_uart(t_hydra_console *con)
 							      CONSOLE_WA_SIZE,
 							      "uart_reader",
 							      NORMALPRIO,
-							      (tfunc_t)uart_reader_thread,
+							      uart_reader_thread,
 							      con);
 				cprint(con, "\x01", 1);
 				break;

--- a/src/hydrabus/hydrabus_mode.c
+++ b/src/hydrabus/hydrabus_mode.c
@@ -91,9 +91,6 @@ const char hydrabus_mode_str_mul_read[] = "READ: ";
 const char hydrabus_mode_str_mul_value_u8[] = "0x%02X ";
 const char hydrabus_mode_str_mul_br[] = "\r\n";
 
-static const char mode_str_delay_us[] = "DELAY %dus\r\n";
-static const char mode_str_delay_ms[] = "DELAY %dms\r\n";
-
 static const char mode_str_write_error[] =  "WRITE error:%d\r\n";
 static const char mode_str_read_error[] = "READ error:%d\r\n";
 static const char mode_str_write_read_error[] = "WRITE/READ error:%d\r\n";
@@ -363,6 +360,7 @@ static int hydrabus_mode_write(t_hydra_console *con, t_tokenline_parsed *p,
 		t++;
 		memcpy(&count, p->buf + p->tokens[t++], sizeof(int));
 		tokens_used += 2;
+		break;
 	case T_ARG_UINT:
 	case T_TILDE:
 		tokens_used += chomp_integers(con, p, t, &num_bytes);

--- a/src/hydrabus/hydrabus_mode_can.c
+++ b/src/hydrabus/hydrabus_mode_can.c
@@ -165,7 +165,7 @@ static void slcan_read_command(t_hydra_console *con, uint8_t *buff){
 	}
 }
 
-msg_t can_reader_thread (void *arg)
+static THD_FUNCTION(can_reader_thread, arg)
 {
 	t_hydra_console *con;
 	con = arg;
@@ -185,7 +185,6 @@ msg_t can_reader_thread (void *arg)
 		}
 	}
 	chThdExit((msg_t)1);
-	return (msg_t)1;
 }
 
 void slcan(t_hydra_console *con) {
@@ -250,7 +249,7 @@ void slcan(t_hydra_console *con) {
 							      CONSOLE_WA_SIZE,
 							      "SLCAN reader",
 							      LOWPRIO,
-							      (tfunc_t)can_reader_thread,
+							      can_reader_thread,
 							      con);
 				cprint(con, "\r", 1);
 			} else {
@@ -474,6 +473,7 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			while(!USER_BUTTON) {
 				read(con, NULL, 0);
 			}
+			break;
 		case T_SLCAN:
 			if(proto->config.can.dev_mode == BSP_CAN_MODE_RO) {
 				bsp_can_mode_rw(proto->dev_num, proto);

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -191,7 +191,7 @@ static uint32_t write(t_hydra_console *con, uint8_t *tx_data, uint8_t nb_data)
 {
 	int i;
 	uint32_t status;
-	bool tx_ack_flag;
+	uint8_t tx_ack_flag;
 	mode_config_proto_t* proto = &con->mode->proto;
 
 	if(proto->config.i2c.ack_pending) {
@@ -300,7 +300,7 @@ static void scan(t_hydra_console *con, t_tokenline_parsed *p)
 {
 	mode_config_proto_t* proto = &con->mode->proto;
 	int i;
-	bool ack, found;
+	uint8_t ack, found;
 
 	(void)p;
 

--- a/src/hydrabus/hydrabus_mode_uart.c
+++ b/src/hydrabus/hydrabus_mode_uart.c
@@ -84,7 +84,7 @@ static int init(t_hydra_console *con, t_tokenline_parsed *p)
 	return tokens_used;
 }
 
-msg_t bridge_thread (void *arg)
+static THD_FUNCTION(bridge_thread, arg)
 {
 	t_hydra_console *con;
 	con = arg;
@@ -107,7 +107,6 @@ msg_t bridge_thread (void *arg)
 			chThdYield();
 		}
 	}
-	return (msg_t)1;
 }
 
 static void bridge(t_hydra_console *con)
@@ -121,7 +120,7 @@ static void bridge(t_hydra_console *con)
 	cprint(con, "\r\n", 2);
 
 	thread_t *bthread = chThdCreateFromHeap(NULL, CONSOLE_WA_SIZE, "bridge_thread",
-						LOWPRIO, (tfunc_t)bridge_thread, con);
+						LOWPRIO, bridge_thread, con);
 	while(!USER_BUTTON) {
 		bytes_read = chnReadTimeout(con->sdu, tx_data,
 					    UART_BRIDGE_BUFF_SIZE, US2ST(100));


### PR DESCRIPTION
Since GCC 8.1 fixes the LTO bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69866), it is possible to use it for compiling HydraFW.

These patches correct some warnings/errors leveraged by GCC 8.1 and change the compilation options to produce RELEASE firmware by default.