### PR TITLE
Fix consecutive BBIO

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -89,6 +89,7 @@ THD_FUNCTION(console, arg)
 		case 0:
 			if (++i == 20) {
 				cmd_bbio(con);
+				i=0;
 			}
 			break;
 		/* SUMP identification is 5*\x00 \x02 */


### PR DESCRIPTION
Allow 2 consecutive entry in binary mode

This fixes a freeze when using flashrom (https://github.com/Baldanos/flashrom) it sends a reset command (which exits binary mode) right after it sends a new sequence of 20 0x00 to enter again binary mode. This result in a variable i equal to 40 but we never entry in binary mode again. 

This might also solve https://github.com/hydrabus/hydrafw/issues/76
