### PR TITLE
Some improvements to pyHydrabus

### DIFF
--- a/contrib/pyHydrabus/pyHydrabus/hydrabus.py
+++ b/contrib/pyHydrabus/pyHydrabus/hydrabus.py
@@ -84,6 +84,15 @@ class Hydrabus:
         """
         self._serialport.reset_input_buffer()
 
+    @property
+    def in_waiting(self):
+        """
+        Return the number of bytes in the receive buffer.
+        :return: Number of bytes
+        :rtype: int
+        """
+        return self._serialport.in_waiting
+
     def exit_bbio(self):
         """
         Reset Hydrabus to CLI mode

--- a/contrib/pyHydrabus/pyHydrabus/hydrabus.py
+++ b/contrib/pyHydrabus/pyHydrabus/hydrabus.py
@@ -131,12 +131,16 @@ class Hydrabus:
         Force reset to BBIO main mode
         :return: Bool
         """
+        timeout = time.time() + 10
         if not self.connected:
             raise serial.SerialException("Not connected.")
         self.timeout = 0.1
         while self.read(5) != b"BBIO1":
             self.flush_input()
             self.write(b"\x00")
+            if time.time() > timeout:
+                self._logger.error(f"Unable to reset hydrabus")
+                return False
         self.timeout = None
         return True
 

--- a/contrib/pyHydrabus/pyHydrabus/protocol.py
+++ b/contrib/pyHydrabus/pyHydrabus/protocol.py
@@ -76,8 +76,8 @@ class Protocol:
     @property
     def hydrabus(self):
         """
-        Return _hydrabus instance to access Hydrabus class function and serial method
-        from any protocol classes instance
+        Return _hydrabus instance to access Hydrabus class functions and serial methods
+        from any protocol classes instances
         :return: _hydrabus class instance
         """
         return self._hydrabus

--- a/contrib/pyHydrabus/pyHydrabus/protocol.py
+++ b/contrib/pyHydrabus/pyHydrabus/protocol.py
@@ -74,6 +74,15 @@ class Protocol:
         self._hydrabus.close()
 
     @property
+    def hydrabus(self):
+        """
+        Return _hydrabus instance to access Hydrabus class function and serial method
+        from any protocol classes instance
+        :return: _hydrabus class instance
+        """
+        return self._hydrabus
+
+    @property
     def timeout(self):
         return self._hydrabus.timeout
 

--- a/contrib/pyHydrabus/pyHydrabus/uart.py
+++ b/contrib/pyHydrabus/pyHydrabus/uart.py
@@ -119,7 +119,6 @@ class UART(Protocol):
     @baud.setter
     def baud(self, value):
         CMD = 0b00000111
-        self._baud = value
 
         self._hydrabus.write(CMD.to_bytes(1, byteorder="big"))
         self._hydrabus.write(value.to_bytes(4, byteorder="big"))


### PR DESCRIPTION
1. Add hydrabus @property in the Protocol class to access hydrabus class functions and serial methods from any protocol classes instances
2. Add in_waiting @property in the Hydrabus class
3. Add a timeout to Hydrabus class reset function, to avoid infinite loop
4. Set _baud value only if accepted by the hydrabus (0x01 returned)