### PR TITLE
Build System: Convert Python scripts to `python3`

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -12,7 +12,7 @@ export STM32F4XX ?= 1
 # Set to 1 HYDRAFW_NFC to include HydraNFC extension support
 export HYDRAFW_NFC ?= 1
 export HYDRAFW_DEBUG ?= 0
-export FW_REVISION := $(shell python build-scripts/hydrafw-revision.py)
+export FW_REVISION := $(shell python3 build-scripts/hydrafw-revision.py)
 
 HYDRAFW_OPTS =
 
@@ -316,19 +316,19 @@ FORCE:
 ifeq ($(USE_VERBOSE_COMPILE),yes)
 	echo Creating ./common/hydrafw_version.hdr
 	-rm -f $(OBJDIR)/common.o
-    python build-scripts/hydrafw-version.py ./common/hydrafw_version.hdr
+    python3 build-scripts/hydrafw-version.py ./common/hydrafw_version.hdr
 else
 	@echo Creating ./common/hydrafw_version.hdr
 	@rm -f $(OBJDIR)/common.o
-	@python build-scripts/hydrafw-version.py ./common/hydrafw_version.hdr
+	@python3 build-scripts/hydrafw-version.py ./common/hydrafw_version.hdr
 endif
 
 %.dfu: %.hex $(LDSCRIPT)
 ifeq ($(USE_VERBOSE_COMPILE),yes)
-	python build-scripts/dfu-convert.py -r $(FW_REVISION) -i $< $@
+	python3 build-scripts/dfu-convert.py -r $(FW_REVISION) -i $< $@
 else
 	@echo Creating $@
-	@python build-scripts/dfu-convert.py -r $(FW_REVISION) -i $< $@
+	@python3 build-scripts/dfu-convert.py -r $(FW_REVISION) -i $< $@
 endif
 
 # This rule hook is defined in the ChibiOS build system

--- a/src/build-scripts/dfu-convert.py
+++ b/src/build-scripts/dfu-convert.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python2
+#!/usr/bin/env python3
 
 # Written by Antonio Galea - 2010/11/18
 # Distributed under Gnu LGPL 3.0
@@ -25,11 +25,11 @@ def rev2byte(revision):
     return (int(ma,16)<<8 | int(mi,16))
 
 def parse(file,dump_images=False):
-  print('File: "%s"' % file)
+  print(('File: "%s"' % file))
   data = open(file,'rb').read()
   crc = compute_crc(data[:-4])
   prefix, data = consume('<5sBIB',data,'signature version size targets')
-  print('%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d' % prefix)
+  print(('%(signature)s v%(version)d, image size: %(size)d, targets: %(targets)d' % prefix))
   for t in range(prefix['targets']):
     tprefix, data  = consume('<6sBI255s2I',data,'signature altsetting named name size elements')
     tprefix['num'] = t
@@ -37,25 +37,25 @@ def parse(file,dump_images=False):
       tprefix['name'] = cstring(tprefix['name'])
     else:
       tprefix['name'] = ''
-    print('%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d' % tprefix)
+    print(('%(signature)s %(num)d, alt setting: %(altsetting)s, name: "%(name)s", size: %(size)d, elements: %(elements)d' % tprefix))
     tsize = tprefix['size']
     target, data = data[:tsize], data[tsize:]
     for e in range(tprefix['elements']):
       eprefix, target = consume('<2I',target,'address size')
       eprefix['num'] = e
-      print('  %(num)d, address: 0x%(address)08x, size: %(size)d' % eprefix)
+      print(('  %(num)d, address: 0x%(address)08x, size: %(size)d' % eprefix))
       esize = eprefix['size']
       image, target = target[:esize], target[esize:]
       if dump_images:
         out = '%s.target%d.image%d.bin' % (file,t,e)
         open(out,'wb').write(image)
-        print('    DUMPED IMAGE TO "%s"' % out)
+        print(('    DUMPED IMAGE TO "%s"' % out))
     if len(target):
-      print("target %d: PARSE ERROR" % t)
+      print(("target %d: PARSE ERROR" % t))
   suffix = named(struct.unpack('<4H3sBI',data[:16]),'device product vendor dfu ufd len crc')
-  print('usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % suffix)
+  print(('usb: %(vendor)04x:%(product)04x, device: 0x%(device)04x, dfu: 0x%(dfu)04x, %(ufd)s, %(len)d, 0x%(crc)08x' % suffix))
   if crc != suffix['crc']:
-    print("CRC ERROR: computed crc32 is 0x%08x" % crc)
+    print(("CRC ERROR: computed crc32 is 0x%08x" % crc))
   data = data[16:]
   if data:
     print("PARSE ERROR")
@@ -103,15 +103,15 @@ if __name__=="__main__":
         try:
           address,binfile = arg.split(':',1)
         except ValueError:
-          print("Address:file couple '%s' invalid." % arg)
+          print(("Address:file couple '%s' invalid." % arg))
           sys.exit(1)
         try:
           address = int(address,0) & 0xFFFFFFFF
         except ValueError:
-          print("Address %s invalid." % address)
+          print(("Address %s invalid." % address))
           sys.exit(1)
         if not os.path.isfile(binfile):
-          print("Unreadable file '%s'." % binfile)
+          print(("Unreadable file '%s'." % binfile))
           sys.exit(1)
         target.append({ 'address': address, 'data': open(binfile,'rb').read() })
     
@@ -123,7 +123,7 @@ if __name__=="__main__":
         try:
           address = address & 0xFFFFFFFF
         except ValueError:
-          print("Address %s invalid." % address)
+          print(("Address %s invalid." % address))
           sys.exit(1)
         target.append({ 'address': address, 'data': data })
 
@@ -143,13 +143,13 @@ if __name__=="__main__":
     try:
       v,d=[int(x,0) & 0xFFFF for x in device.split(':',1)]
     except:
-      print("Invalid device '%s'." % device)
+      print(("Invalid device '%s'." % device))
       sys.exit(1)
     build(outfile,[target],device, revision)
   elif len(args)==1:
     infile = args[0]
     if not os.path.isfile(infile):
-      print("Unreadable file '%s'." % infile)
+      print(("Unreadable file '%s'." % infile))
       sys.exit(1)
     parse(infile, dump_images=options.dump_images)
   else:

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 from git import *
 import re
 
@@ -5,4 +7,4 @@ r = re.compile("v(\d+\.\d+).*")
 
 git=Repo(search_parent_directories=True).git
 version = git.describe(tags=True,always=True,dirty=True,long=True)
-print(r.search(version).group(1))
+print((r.search(version).group(1)))

--- a/src/build-scripts/hydrafw-version.py
+++ b/src/build-scripts/hydrafw-version.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 import sys
 from optparse import OptionParser
 from datetime import *
@@ -12,8 +14,8 @@ parser = OptionParser(usage=usage)
 if len(args)==1:
   sys.stdout = open(args[0], 'w')
   git=Repo(search_parent_directories=True).git
-  print('#define HYDRAFW_GIT_TAG "' + git.describe(tags=True,always=True,dirty=True,long=True) + '"')
-  print('#define HYDRAFW_CHECKIN_DATE "' + git.show(['-s', '--pretty=format:%ai']).partition(' ')[0] + '"')
+  print(('#define HYDRAFW_GIT_TAG "' + git.describe(tags=True,always=True,dirty=True,long=True) + '"'))
+  print(('#define HYDRAFW_CHECKIN_DATE "' + git.show(['-s', '--pretty=format:%ai']).partition(' ')[0] + '"'))
 else:
   parser.print_help()
   sys.exit(1)


### PR DESCRIPTION
Change `Makefile` to invoke the Python scripts using the `python3` interpreter, as well as using the `2to3` suggested changes to the scripts. Please note that the s/long/int/ change is not taken, as the python3-git module has a "long" option (for a `git describe` binding) which is obviously not an integer type but requests the long listing format...