### PR TITLE
onewire: Implement `scan` for multiple devices

### DIFF
--- a/src/hydrabus/hydrabus_mode_onewire.h
+++ b/src/hydrabus/hydrabus_mode_onewire.h
@@ -38,4 +38,15 @@ void onewire_send_bit(t_hydra_console *con, uint8_t bit);
 uint8_t onewire_read_bit(t_hydra_console *con);
 void onewire_cleanup(t_hydra_console *con);
 void onewire_start(t_hydra_console *con);
-void onewire_scan(t_hydra_console *con);
+
+struct onewire_scan_state {
+	uint8_t ROM_ADDR[8];
+	int last_discrepancy;
+	int last_family_discrepancy;
+	bool last_device_p;
+	uint8_t crc8;
+};
+enum onewire_scan_mode {
+	onewire_scan_start,
+	onewire_scan_continue,
+};


### PR DESCRIPTION
The former `scan` command only worked with a single 1-wire device attached. However, the 1-wire bus is ment as a bus, so there might be several devices connected to the bus. In that case, there is a suggested bus scanning scheme (cf. https://www.maximintegrated.com/en/design/technical-documents/app-notes/1/187.html) that makes clever use of pull-down collisions that will occur in such a situation. This allows to scan for all devices by basically doing a tree search. (The algorithm avoids recursion by using a few house-keeping variables to keep search state while discovering all devices ROM addresses.)