### PR TITLE
I2C: Add clock stretching support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,5 @@ hydrafwEm.elay
 *.hdr
 /src/.settings
 /src/.idea/
+.vscode/
 src/hydrafw Debug.launch

--- a/src/common/mode_config.h
+++ b/src/common/mode_config.h
@@ -88,6 +88,7 @@ typedef struct {
 	uint32_t dev_speed;
 	uint8_t ack_pending : 1;
 	uint8_t dev_mode;
+	uint32_t dev_clock_stretch_timeout;
 } i2c_config_t;
 
 typedef struct {

--- a/src/drv/stm32cube/bsp_i2c_master.c
+++ b/src/drv/stm32cube/bsp_i2c_master.c
@@ -228,7 +228,7 @@ static void i2c_master_set_scl_float_and_wait_ready(void)
 			++clock_stretch_count;
 		}
 
-		if (clock_stretch_count == i2c_clock_strech_timeout) {
+		if (i2c_clock_strech_timeout != 0 && clock_stretch_count == i2c_clock_strech_timeout) {
 			printf_dbg("\nI2C clock streching timeout: half cycle count = %d\n", clock_stretch_count);
 		}
 	}

--- a/src/drv/stm32cube/bsp_i2c_master.c
+++ b/src/drv/stm32cube/bsp_i2c_master.c
@@ -31,7 +31,7 @@ const int i2c_speed[I2C_SPEED_MAX] = {
 };
 int i2c_speed_delay;
 bool i2c_started;
-int i2c_clock_strech_timeout = 300;
+uint32_t i2c_clock_strech_timeout;
 
 /* Set SCL LOW = 0/GND (0/GND => Set pin = logic reversed in open drain) */
 #define set_scl_low() (gpio_set_pin(BSP_I2C1_SCL_SDA_GPIO_PORT, BSP_I2C1_SCL_PIN))
@@ -204,7 +204,7 @@ bsp_status_t bsp_i2c_stop(bsp_dev_i2c_t dev_num)
  */
 static void i2c_master_set_scl_float_and_wait_ready(void)
 {
-	int clock_stretch_count;
+	uint32_t clock_stretch_count;
 	unsigned char scl_val;
 
 	set_scl_float();
@@ -220,7 +220,10 @@ static void i2c_master_set_scl_float_and_wait_ready(void)
 		// have to put a timer to avoid dead loop here. However, when this happens (usually a faulty device), there is nothing
 		// we could do in master, but fail and move on.
 		while (scl_val == 0 && clock_stretch_count < i2c_clock_strech_timeout) {
+			// We always wait for a full clock cycle before checking the clock line.
 			i2c_sw_delay();
+			i2c_sw_delay();
+
 			scl_val = get_scl();
 			++clock_stretch_count;
 		}

--- a/src/drv/stm32cube/bsp_i2c_master.c
+++ b/src/drv/stm32cube/bsp_i2c_master.c
@@ -229,7 +229,7 @@ static void i2c_master_set_scl_float_and_wait_ready(void)
 		}
 
 		if (i2c_clock_strech_timeout != 0 && clock_stretch_count == i2c_clock_strech_timeout) {
-			printf_dbg("\nI2C clock streching timeout: half cycle count = %d\n", clock_stretch_count);
+			printf_dbg("\nI2C clock streching timeout: waited tick count = %u\n", clock_stretch_count);
 		}
 	}
 }

--- a/src/drv/stm32cube/bsp_i2c_master.h
+++ b/src/drv/stm32cube/bsp_i2c_master.h
@@ -35,6 +35,6 @@ bsp_status_t bsp_i2c_stop(bsp_dev_i2c_t dev_num);
 
 bsp_status_t bsp_i2c_master_write_u8(bsp_dev_i2c_t dev_num, uint8_t tx_data, uint8_t* tx_ack_flag);
 bsp_status_t bsp_i2c_master_read_u8(bsp_dev_i2c_t dev_num, uint8_t* rx_data);
-void bsp_i2c_read_ack(bsp_dev_i2c_t dev_num, bool enable_ack);
+bsp_status_t bsp_i2c_read_ack(bsp_dev_i2c_t dev_num, bool enable_ack);
 
 #endif /* _BSP_I2C_MASTER_H_ */

--- a/src/hydrabus/commands.c
+++ b/src/hydrabus/commands.c
@@ -163,6 +163,7 @@ const t_token_dict tl_dict[] = {
 	{ T_CONVENTION, "convention" },
 	{ T_DELAY, "delay" },
 	{ T_MMC, "mmc" },
+	{ T_CLOCK_STRETCH, "clock-stretch" },
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */
@@ -913,6 +914,11 @@ t_token tokens_can[] = {
 		T_FREQUENCY,\
 		.arg_type = T_ARG_FLOAT,\
 		.help = "Bus frequency"\
+	},\
+	{\
+		T_CLOCK_STRETCH,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Max clock stretch tick count. (0 = Disable)"\
 	},
 
 t_token tokens_mode_i2c[] = {

--- a/src/hydrabus/commands.c
+++ b/src/hydrabus/commands.c
@@ -918,7 +918,7 @@ t_token tokens_can[] = {
 	{\
 		T_CLOCK_STRETCH,\
 		.arg_type = T_ARG_UINT,\
-		.help = "Max clock stretch tick count. (0 = Disable)"\
+		.help = "Max clock stretch tick count. (0 = Disabled, n = Ticks)"\
 	},
 
 t_token tokens_mode_i2c[] = {

--- a/src/hydrabus/commands.h
+++ b/src/hydrabus/commands.h
@@ -155,6 +155,7 @@ enum {
 	T_CONVENTION,
 	T_DELAY,
 	T_MMC,
+	T_CLOCK_STRETCH,
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -89,7 +89,7 @@ static void show_params(t_hydra_console *con)
 	cprintf(con, ")\r\n");
 
 	clock_stretch_timeout_time_in_microseconds = proto->config.i2c.dev_clock_stretch_timeout * 1000000.0 / speeds[proto->config.i2c.dev_speed];
-	cprintf(con, "Clock stretch timeout: %d ticks / %.2lf us (0 = Disabled, n = ticks)\r\n",
+	cprintf(con, "Clock stretch timeout: %d ticks / %.2lf us (0 = Disabled, n = Ticks)\r\n",
 		proto->config.i2c.dev_clock_stretch_timeout,
 		clock_stretch_timeout_time_in_microseconds);
 }

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -61,6 +61,7 @@ static void init_proto_default(t_hydra_console *con)
 	proto->config.i2c.dev_speed = 1;
 	proto->config.i2c.ack_pending = 0;
 	proto->config.i2c.dev_mode = DEV_MASTER;
+	proto->config.i2c.dev_clock_stretch_timeout = 0;
 }
 
 static void show_params(t_hydra_console *con)
@@ -85,6 +86,8 @@ static void show_params(t_hydra_console *con)
 		print_freq(con, speeds[i]);
 	}
 	cprintf(con, ")\r\n");
+
+	cprintf(con, "Clock stretch timeout (ticks): %d (0 = Disabled)\r\n", proto->config.i2c.dev_clock_stretch_timeout);
 }
 
 static int init(t_hydra_console *con, t_tokenline_parsed *p)
@@ -147,6 +150,15 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 				cprintf(con, "Invalid frequency.\r\n");
 				return t;
 			}
+			bsp_status = bsp_i2c_master_init(proto->dev_num, proto);
+			if( bsp_status != BSP_OK) {
+				cprintf(con, str_bsp_init_err, bsp_status);
+				return t;
+			}
+			break;
+		case T_CLOCK_STRETCH:
+			t += 2;
+			memcpy(&proto->config.i2c.dev_clock_stretch_timeout, p->buf + p->tokens[t], sizeof(int));
 			bsp_status = bsp_i2c_master_init(proto->dev_num, proto);
 			if( bsp_status != BSP_OK) {
 				cprintf(con, str_bsp_init_err, bsp_status);

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -255,8 +255,9 @@ static uint32_t write(t_hydra_console *con, uint8_t *tx_data, uint8_t nb_data)
 
 		cprintf(con, " ");
 		if (i2c_io_failed(con, status))
-			break;
+			return status;
 	}
+
 	cprintf(con, hydrabus_mode_str_mul_br);
 
 	return status;
@@ -274,7 +275,7 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 			/* Send I2C ACK */
 			status = bsp_i2c_read_ack(I2C_DEV_NUM, TRUE);
 			if (i2c_io_failed(con, status))
-				return status;
+				break;
 
 			cprintf(con, str_i2c_ack);
 			cprintf(con, hydrabus_mode_str_mul_br);

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -89,7 +89,7 @@ static void show_params(t_hydra_console *con)
 	cprintf(con, ")\r\n");
 
 	clock_stretch_timeout_time_in_microseconds = proto->config.i2c.dev_clock_stretch_timeout * 1000000.0 / speeds[proto->config.i2c.dev_speed];
-	cprintf(con, "Clock stretch timeout: %d ticks / %.2lf us (0 = Disabled, n = Ticks)\r\n",
+	cprintf(con, "Clock stretch timeout: %d ticks / %.2lf us (0 = Disabled)\r\n",
 		proto->config.i2c.dev_clock_stretch_timeout,
 		clock_stretch_timeout_time_in_microseconds);
 }

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -67,6 +67,7 @@ static void init_proto_default(t_hydra_console *con)
 static void show_params(t_hydra_console *con)
 {
 	uint8_t i, cnt;
+	float clock_stretch_timeout_time_in_microseconds;
 	mode_config_proto_t* proto = &con->mode->proto;
 
 	cprintf(con, "GPIO resistor: %s\r\nMode: %s\r\nFrequency: ",
@@ -87,7 +88,10 @@ static void show_params(t_hydra_console *con)
 	}
 	cprintf(con, ")\r\n");
 
-	cprintf(con, "Clock stretch timeout (ticks): %d (0 = Disabled)\r\n", proto->config.i2c.dev_clock_stretch_timeout);
+	clock_stretch_timeout_time_in_microseconds = proto->config.i2c.dev_clock_stretch_timeout * 1000000.0 / speeds[proto->config.i2c.dev_speed];
+	cprintf(con, "Clock stretch timeout: %d ticks / %.2lf us (0 = Disabled, n = ticks)\r\n",
+		proto->config.i2c.dev_clock_stretch_timeout,
+		clock_stretch_timeout_time_in_microseconds);
 }
 
 static int init(t_hydra_console *con, t_tokenline_parsed *p)


### PR DESCRIPTION
This change adds the ability of handling i2c clock stretching. Clock stretching could happen on certain devices, such as BNO055 and PN532. When it happens, we could not sending the I2C read/writes blindly, but have to wait until the SCL coming back to high before sending the next bits. Otherwise, the SDA signals will be ignored by the device and ends up with incorrect communication.

However, clock stretching can cause I2C bus hang indefinitely by faulty devices, so many devices doesn't do clock stretching at all. So due to the rareness of clock stretching, this feature is turned off by default. And we need to explicitly enable it with the following command when running in i2c mode:

```
clock-stretch <clock-tick-count>
```

If we specify 0, it will disable the feature, otherwise it means how many full clock ticks we wait. This also means the final time that we waits depends on the frequency that we use. If the frequency is 100Khz, it means every clock tick will be 10us. If we specify `clock-stretch 100`, we will be waiting at maximum 1ms. But if the frequency is 1Mhz, we will be waiting 100us. 

We choose the ticks instead of time in the setting, because it match more on the actual behavior and not every time interval can be mapped to a set of complete full clock ticks.