### PR TITLE
src/Makefile: add target to flash firmware for convenience

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -349,7 +349,7 @@ POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).dfu
 flash: $(BUILDDIR)/$(PROJECT).dfu
 	@echo Flashing $^
 ifeq ($(OS), Windows_NT)
-	./utils/windows_dfu_util/DfuSeCommand.exe -c --de 0 -d --fn $^
+	@./utils/windows_dfu_util/DfuSeCommand.exe -c --de 0 -d --fn $^
 else
 	@dfu-util -d 0483:df11 -a 0 -R -D $^
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -349,7 +349,7 @@ POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).dfu
 flash: $(BUILDDIR)/$(PROJECT).dfu
 	@echo Flashing $^
 ifeq ($(OS), Windows_NT)
-	@./utils/windows_dfu_util/DfuSeCommand.exe -c --de 0 -d --fn $^
+	@../utils/windows_dfu_util/DfuSeCommand.exe -c --de 0 -d --fn $^
 else
 	@dfu-util -d 0483:df11 -a 0 -R -D $^
 endif

--- a/src/Makefile
+++ b/src/Makefile
@@ -348,4 +348,4 @@ POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).dfu
 # Custom rule to flash firmware when hydrabus is connected in dfu mode
 flash: $(BUILDDIR)/$(PROJECT).dfu
 	@echo Flashing $^
-	@dfu-util  -d 0483:df11  -a 0  -D $^
+	@dfu-util -d 0483:df11 -a 0 -R -D $^

--- a/src/Makefile
+++ b/src/Makefile
@@ -344,3 +344,8 @@ PRE_MAKE_ALL_RULE_HOOK: ./common/hydrafw_version.hdr
 
 # This rule hook is defined in the ChibiOS build system
 POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).dfu
+
+# Custom rule to flash firmware when hydrabus is connected in dfu mode
+flash: $(BUILDDIR)/$(PROJECT).dfu
+	@echo Flashing $^
+	@dfu-util  -d 0483:df11  -a 0  -D $^

--- a/src/Makefile
+++ b/src/Makefile
@@ -348,4 +348,8 @@ POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).dfu
 # Custom rule to flash firmware when hydrabus is connected in dfu mode
 flash: $(BUILDDIR)/$(PROJECT).dfu
 	@echo Flashing $^
+ifeq ($(OS), Windows_NT)
+	./utils/windows_dfu_util/DfuSeCommand.exe -c --de 0 -d --fn $^
+else
 	@dfu-util -d 0483:df11 -a 0 -R -D $^
+endif


### PR DESCRIPTION
Hello. Just decided to share this tiny improvement for the main `Makefile`: in the case of _compile-flash-run_ cycle, now just putting the device into _dfu mode_ & running `make flash` will do the rest automagically. Can't wait to hear any feedback about this patch.