### PR TITLE
Arch Linux Fix autosuspend send by TLP daemon

### DIFF
--- a/utils/udev-rules/09-hydrabus-arch_linux.rules
+++ b/utils/udev-rules/09-hydrabus-arch_linux.rules
@@ -1,0 +1,11 @@
+# UDEV Rules for HydraBus boards, http://www.hydrabus.com
+#
+# To install, type this command in a terminal:
+#   sudo cp 09-hydrabus.rules /etc/udev/rules.d/09-hydrabus.rules
+#
+# disable ModemManager
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", ENV{ID_MM_DEVICE_IGNORE}="1"
+# disable autosuspend USB from kernel (solve TLP issue)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", TEST=="power/control", ATTR{power/control}="on"
+# create a symlink into /dev/hydrabus
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", SYMLINK+="hydrabus"

--- a/utils/udev-rules/09-hydrabus-arch_linux.rules
+++ b/utils/udev-rules/09-hydrabus-arch_linux.rules
@@ -1,4 +1,4 @@
-# UDEV Rules for HydraBus boards, http://www.hydrabus.com
+# UDEV Rules for HydraBus boards tested on Arch Linux 27 Nov 2023, http://www.hydrabus.com
 #
 # To install, type this command in a terminal:
 #   sudo cp 09-hydrabus-arch_linux.rules /etc/udev/rules.d/09-hydrabus-arch_linux.rules
@@ -8,4 +8,4 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", ENV{ID_MM_
 # disable autosuspend USB from kernel (solve TLP issue)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", TEST=="power/control", ATTR{power/control}="on"
 # create a symlink into /dev/hydrabusX where X is the number of hydrabus
-SUBSYSTEM=="tty", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", SYMLINK+="hydrabus%n"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", PROGRAM="/bin/sh -c 'echo $$((%n+1))'", SYMLINK+="hydrabus%c"

--- a/utils/udev-rules/09-hydrabus-arch_linux.rules
+++ b/utils/udev-rules/09-hydrabus-arch_linux.rules
@@ -7,5 +7,5 @@
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", ENV{ID_MM_DEVICE_IGNORE}="1"
 # disable autosuspend USB from kernel (solve TLP issue)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", TEST=="power/control", ATTR{power/control}="on"
-# create a symlink into /dev/hydrabus
-SUBSYSTEM=="tty", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", SYMLINK+="hydrabus"
+# create a symlink into /dev/hydrabusX where X is the number of hydrabus
+SUBSYSTEM=="tty", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", SYMLINK+="hydrabus%n"

--- a/utils/udev-rules/09-hydrabus-arch_linux.rules
+++ b/utils/udev-rules/09-hydrabus-arch_linux.rules
@@ -1,7 +1,7 @@
 # UDEV Rules for HydraBus boards, http://www.hydrabus.com
 #
 # To install, type this command in a terminal:
-#   sudo cp 09-hydrabus.rules /etc/udev/rules.d/09-hydrabus.rules
+#   sudo cp 09-hydrabus-arch_linux.rules /etc/udev/rules.d/09-hydrabus-arch_linux.rules
 #
 # disable ModemManager
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1d50", ATTRS{idProduct}=="60a7", ENV{ID_MM_DEVICE_IGNORE}="1"


### PR DESCRIPTION
This PR fix a problem found in [TLP](https://wiki.archlinux.org/title/TLP) where by default all USB device are set to autosuspend, thus sometimes creating weird issue on the hydrabus.
It also create a symlink into /dev/hydrabusX where X is the number of hydrabus connected (with X starting at 1).