### PR TITLE
src/Makefile: correcting tabulation to fix verbose build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -324,7 +324,7 @@ FORCE:
 ifeq ($(USE_VERBOSE_COMPILE),yes)
 	echo Creating ./common/hydrafw_version.hdr
 	-rm -f $(OBJDIR)/common.o
-    $(PYTHON) build-scripts/hydrafw-version.py ./common/hydrafw_version.hdr
+	$(PYTHON) build-scripts/hydrafw-version.py ./common/hydrafw_version.hdr
 else
 	@echo Creating ./common/hydrafw_version.hdr
 	@rm -f $(OBJDIR)/common.o


### PR DESCRIPTION
TL; DR: fix tab for `USE_VERBOSE_COMPILE=yes  make` use case.

Hello again. I have a couple of other ideas for further little improvements of `src/Makefile`, if no one minds. But during experiments, I discovered a very little issue which I'm happy to help to fix first.

Steps to reproduce:
  - run a local build with verbose output using supported `make` variable:  
`$ USE_VERBOSE_COMPILE=yes  make`

What should happen? :
  - successfull local build with detailed output

What actually happens? :
  - build stops due to error:
`Makefile:327: *** missing separator.  Stop.`

Root cause:
  - a set of spaces placed in the line with error instead of tab

Hence, this microscopic PR commit fixes verbose building.
