### PR TITLE
src/Makefile: make 'make clean' clean all produced files

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -342,6 +342,9 @@ PRE_MAKE_ALL_RULE_HOOK: ./common/hydrafw_version.hdr
 # This rule hook is defined in the ChibiOS build system
 POST_MAKE_ALL_RULE_HOOK: $(BUILDDIR)/$(PROJECT).dfu
 
+# This rule hook for `make clean` is defined in the ChibiOS build system
+CLEAN_RULE_HOOK: $(shell rm -f ./common/hydrafw_version.hdr)
+
 # Custom rule to flash firmware when hydrabus is connected in dfu mode
 flash: $(BUILDDIR)/$(PROJECT).dfu
 	$(OUT_LOG) echo Flashing $^


### PR DESCRIPTION
TL; DR: make `make clean` clean _all_ produced files.

Steps to reproduce:
 - run build: `$ make`
 - clean produced files: `$ make clean`

What should happen:
 - usually, it's a common practice when after `make clean` _all_ produced files are deleted

What actually happens:
 - `src/common/hydrafw_version.hdr` kept as _"leftover"_


At first I was thinking about adding a separate `clean` target into `Makefile` but since internal variables of `rules.mk` from `ChibiOS` support "custom enhancements", just adding command `rm -f src/common/hydrafw_version.hdr` to special variable do the trick.

I did successfully test it myself on `Ubuntu 18.04`. But I did not test it on `Windows`/`mingw` unfortunately.

P.S. Happy New Year! :)