### PR TITLE
src/hydrabus/commands.c: improve help output on some console commands

### DIFF
--- a/src/hydrabus/commands.c
+++ b/src/hydrabus/commands.c
@@ -238,12 +238,12 @@ t_token tokens_mode_brute[] = {
 	{
 		T_BYPASS,
 		.arg_type = T_ARG_UINT,
-		.help = "Performs a BYPASS scan on n pins"
+		.help = "Performs a BYPASS scan on x pins (PB0 up to PB11)"
 	},
 	{
 		T_IDCODE,
 		.arg_type = T_ARG_UINT,
-		.help = "Performs an IDCODE scan on n pins"
+		.help = "Performs an IDCODE scan on x pins (PB0 up to PB11)"
 	},
 	{ }
 };
@@ -1462,7 +1462,7 @@ t_token tokens_mode_twowire[] = {
 	{
 		T_BRUTE,
 		.arg_type = T_ARG_UINT,
-		.help = "Perform a SWD enumeration on pins"
+		.help = "Perform a SWD enumeration on x pins (PB0 up to PB11)"
 	},
 	{
 		T_ARG_UINT,


### PR DESCRIPTION
Hello. Just another tiny help - patch to close [the related task](https://github.com/hydrabus/hydrafw/issues/152).

The local build has been successfully tested. The log from my `hydrabus`:
```
> jtag
Device: JTAG1
GPIO resistor: pull-up
Frequency: 2000000Hz
Bit order: LSB first
jtag1> help brute
Bruteforce JTAG pins on x pins starting from PB0
   bypass         Performs a BYPASS scan on x pins (PB0 up to PB11)
   idcode         Performs an IDCODE scan on x pins (PB0 up to PB11)
jtag1> exit
> 2-wire
Device: twowire1
GPIO resistor: floating
Frequency: 1000000Hz
Bit order: MSB first
twowire1> help brute
Perform a SWD enumeration on x pins (PB0 up to PB11)
twowire1> exit
>
```

Is it ok? Or should the `2-wire` help output be in _**the full accordance**_ with [wiki](https://github.com/hydrabus/hydrafw/wiki/HydraFW-2wire-guide/_compare/af9b1fae21b2a49ad27607f37a65414398f1629e), i.e. "`Perform a SWD enumeration on x pins (PB0 up to PB11) with x from 2 to 11`"? Let me know.