### PR TITLE
src/Makefile: add V=1 parsing to enable verbose compile in easier classic way

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -79,6 +79,10 @@ ifeq ($(USE_THUMB),)
 endif
 
 # Enable this if you want to see the full log while compiling.
+ifeq ($(V),1)
+  USE_VERBOSE_COMPILE = yes
+endif
+
 # Also set directives to use with commands depending on verbosity status.
 ifeq ($(USE_VERBOSE_COMPILE),yes)
   # if verbose build then print out the full commands without description


### PR DESCRIPTION
TL; DR: add support for `V=1` (in addition to `USE_VERBOSE_COMPILE=yes`).

Since this is a well-known common practice for open-source projects to enable verbose build just by adding `V=1` into build command, I thought this may be useful here as well - it's way much faster & easier to use.