### PR TITLE
Add timed read for smartcards + littles changes

### DIFF
--- a/src/drv/stm32cube/bsp_smartcard.c
+++ b/src/drv/stm32cube/bsp_smartcard.c
@@ -79,7 +79,7 @@ static void smartcard_gpio_hw_init(bsp_dev_smartcard_t dev_num)
 	/*SMARTCARD1 CD pin configuration*/
 	GPIO_InitStructure.Pin = BSP_SMARTCARD1_CD_PIN;
 	GPIO_InitStructure.Mode = GPIO_MODE_INPUT;
-	GPIO_InitStructure.Pull = GPIO_NOPULL;
+	GPIO_InitStructure.Pull = GPIO_PULLUP;
 	HAL_GPIO_Init(BSP_SMARTCARD1_CD_PORT, &GPIO_InitStructure);
 }
 
@@ -142,7 +142,7 @@ bsp_status_t bsp_smartcard_init(bsp_dev_smartcard_t dev_num, mode_config_proto_t
 	hsmartcard->Instance = BSP_SMARTCARD1;
 
 	/* Defaults */
-	hsmartcard->Init.BaudRate 		= 9600; /* Starting baudrate = 3,5MHz / 372etu */
+	hsmartcard->Init.BaudRate 		= 9408; /* Starting baudrate = 3,5MHz / 372etu */
 	hsmartcard->Init.WordLength 		= SMARTCARD_WORDLENGTH_9B;
 	hsmartcard->Init.StopBits 		= SMARTCARD_STOPBITS_1_5;
 	hsmartcard->Init.Parity 		= SMARTCARD_PARITY_EVEN;

--- a/src/hydrabus/hydrabus_bbio_smartcard.c
+++ b/src/hydrabus/hydrabus_bbio_smartcard.c
@@ -27,7 +27,7 @@
 #include "hydrabus_bbio_smartcard.h"
 #include "bsp_smartcard.h"
 
-#define SMARTCARD_DEFAULT_SPEED (9600)
+#define SMARTCARD_DEFAULT_SPEED (9408)
 
 void bbio_smartcard_init_proto_default(t_hydra_console *con)
 {

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -22,7 +22,7 @@
 #include "bsp_smartcard.h"
 #include <string.h>
 
-#define SMARTCARD_DEFAULT_SPEED (9600)
+#define SMARTCARD_DEFAULT_SPEED (9408)
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);


### PR DESCRIPTION
Hi,

Here's a patch adding a command to receive a smartcard message with a timeout. 
With the existing code, a successful read can only be achieved by specifying the exact number of characters (or less). This works: 

```
smartcard1> ]%%[read:18 
RST DOWN
DELAY: 1 ms
DELAY: 1 ms
RST UP
READ: 0x3B 0xF8 0x13 0x00 0x00 0x81 0x31 0xFE 0x45 0x4A 0x43 0x4F 0x50 0x76 0x32 0x34 0x31 0xB7 
```
But not this:
```
smartcard1> ]%%[read:33
RST DOWN
DELAY: 1 ms
DELAY: 1 ms
RST UP
READ error:3
```
Of course, ATR is just an example, we don't always know the size of the data returned by the card.. So I added a new `tread` (timed read) command and a `timeout` parameter. And now we can do this:

```
> smartcard 
Device: SMARTCARD1
Speed: 9408 bps
Parity: even
Stop bits: 1.5
Convention: normal
Prescaler: 12 / 3.50mhz
Timeout: 10000 msec

smartcard1> timeout 2000

smartcard1> ]%%[tread:33
RST DOWN
DELAY: 1 ms
DELAY: 1 ms
RST UP
READ: 0x3B 0xF8 0x13 0x00 0x00 0x81 0x31 0xFE 0x45 0x4A 0x43 0x4F 0x50 0x76 0x32 0x34 0x31 0xB7 
                                                                                                                     
smartcard1> 0x00 0x00 0x0f 0x00 0xa4 0x04 0x00 0x0a 0xf2 0x76 0xa2 0x88 0xbc 0xde 0xad 0xbe 0xef 0x01 0x94 % tread:18
WRITE: 0x00 0x00 0x0F 0x00 0xA4 0x04 0x00 0x0A 0xF2 0x76 0xA2 0x88 0xBC 0xDE 0xAD 0xBE 0xEF 0x01 0x94 
DELAY: 1 ms
READ: 0x00 0x00 0x02 0x90 0x00 0x92 
                                                                 
smartcard1> 0x00 0x40 0x05 0x80 0x50 0x00 0x00 0x01 0x94 tread:10
WRITE: 0x00 0x40 0x05 0x80 0x50 0x00 0x00 0x01 0x94 
READ: 0x00 0x40 0x03 0x0A 0x90 0x00 0xD9 
            
smartcard1>
```
Here, after the ATR, I selected the application on the smartcard (NXP J2A081, T=1 protocol) and used an APDU for a counter reading.

I have also configured a pull-up resistor on PA7 so that the normally closed contactor on the card reader opens and `query` displays `CD=1` when the card is present.

Finally, the default communication speed should be 9408 bps because (1/((1/3500000)*372)). 9600 bps is a rounding-off that works but the ETU is normally 106µs with a 3.5 MHz clock.

Perhaps timeout read could be interesting for other buses too.