### PR TITLE
Small cleanups.

### DIFF
--- a/src/common/microsd.c
+++ b/src/common/microsd.c
@@ -24,9 +24,6 @@
 
 #include "ff.h"
 
-#include "usb1cfg.h"
-#include "usb2cfg.h"
-
 #include "microsd.h"
 #include "common.h"
 

--- a/src/drv/stm32cube/bsp.c
+++ b/src/drv/stm32cube/bsp.c
@@ -16,6 +16,7 @@ limitations under the License.
 #include "ch.h"
 #include "osal.h"
 
+#include "hal_lld.h"
 #include "bsp.h"
 #include "bsp_gpio.h"
 
@@ -66,12 +67,12 @@ uint32_t HAL_GetTick(void)
 
 uint32_t HAL_RCC_GetPCLK1Freq(void)
 {
-	return 42000000;
+	return STM32_PCLK1;
 }
 
 uint32_t HAL_RCC_GetPCLK2Freq(void)
 {
-	return 84000000;
+	return STM32_PCLK2;
 }
 
 bool delay_is_expired(bool start, uint32_t wait_nb_cycles)
@@ -108,7 +109,7 @@ void wait_delay(uint32_t wait_nb_cycles)
 
 uint32_t bsp_get_apb1_freq(void)
 {
-	return 42000000;
+	return STM32_PCLK1;
 }
 
 void reboot_usb_dfu(void)

--- a/src/hydrabus/hydrabus_sd.c
+++ b/src/hydrabus/hydrabus_sd.c
@@ -24,9 +24,6 @@
 
 #include "ff.h"
 
-#include "usb1cfg.h"
-#include "usb2cfg.h"
-
 #include "microsd.h"
 #include "hydrabus_sd.h"
 #include "common.h"


### PR DESCRIPTION
Don't hardcode PCLK frequencies.
Remove unused #includes.
Enable USB2 console only when the peripheral exist.