### PR TITLE
Add read with timeout feature

### DIFF
--- a/src/common/mode_config.h
+++ b/src/common/mode_config.h
@@ -175,6 +175,7 @@ typedef struct {
 #define MODE_CONFIG_PROTO_BUFFER_SIZE (256)
 typedef struct {
 	uint8_t dev_num;
+	uint32_t timeout;
 	union {
 		uart_config_t uart;
 		smartcard_config_t smartcard;

--- a/src/drv/stm32cube/bsp_smartcard.c
+++ b/src/drv/stm32cube/bsp_smartcard.c
@@ -273,34 +273,6 @@ bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data
 }
 
 /**
-  * @brief  Read bytes in blocking mode, with timeout
-  * @param  dev_num: SMARTCARD dev num.
-  * @param  rx_data: Data to receive.
-  * @param  nb_data: Number of data to receive.
-  * @param  timeout: Number of ticks to wait
-  * @retval Number of bytes read
-  */
-bsp_status_t bsp_smartcard_read_u8_timeout(bsp_dev_smartcard_t dev_num, uint8_t* rx_data,
-        uint8_t nb_data, uint32_t timeout)
-{
-	SMARTCARD_HandleTypeDef* hsmartcard;
-	hsmartcard = &smartcard_handle[dev_num];
-
-	bsp_status_t status;
-	__HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
-	status = (bsp_status_t) HAL_SMARTCARD_Receive(hsmartcard, rx_data, nb_data, timeout);
-	switch(status) {
-	case BSP_OK:
-	case BSP_TIMEOUT:
-		return (nb_data-(hsmartcard->RxXferCount)-1);
-	case BSP_ERROR:
-	default:
-		smartcard_error(dev_num);
-		return 0;
-	}
-}
-
-/**
   * @brief  Send a byte then Read a byte through the SMARTCARD interface.
   * @param  tx_data: Data to send.
   * @param  rx_data: Data to receive.

--- a/src/drv/stm32cube/bsp_smartcard.c
+++ b/src/drv/stm32cube/bsp_smartcard.c
@@ -243,16 +243,18 @@ bsp_status_t bsp_smartcard_write_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_dat
   * @param  dev_num: SMARTCARD dev num.
   * @param  rx_data: Data to receive.
   * @param  nb_data: Number of data to receive.
-  * @retval status of the transfer.
+  * @param  timeout: Number of miliseconds to wait
+  * @retval status of the transfer. nb_data will contain the number of read
+  * bytes
   */
-bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data)
+bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data, uint32_t timeout)
 {
 	SMARTCARD_HandleTypeDef* hsmartcard;
 	hsmartcard = &smartcard_handle[dev_num];
 
 	bsp_status_t status;
 	__HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
-	status = (bsp_status_t) HAL_SMARTCARD_Receive(hsmartcard, rx_data, *nb_data, SMARTCARDx_TIMEOUT_MAX);
+	status = (bsp_status_t) HAL_SMARTCARD_Receive(hsmartcard, rx_data, *nb_data, timeout);
 
 	switch(status){
 	case BSP_OK:

--- a/src/drv/stm32cube/bsp_smartcard.c
+++ b/src/drv/stm32cube/bsp_smartcard.c
@@ -245,18 +245,28 @@ bsp_status_t bsp_smartcard_write_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_dat
   * @param  nb_data: Number of data to receive.
   * @retval status of the transfer.
   */
-bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t nb_data)
+bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data)
 {
 	SMARTCARD_HandleTypeDef* hsmartcard;
 	hsmartcard = &smartcard_handle[dev_num];
 
 	bsp_status_t status;
 	__HAL_SMARTCARD_FLUSH_DRREGISTER(hsmartcard);
-	status = (bsp_status_t) HAL_SMARTCARD_Receive(hsmartcard, rx_data, nb_data, SMARTCARDx_TIMEOUT_MAX);
+	status = (bsp_status_t) HAL_SMARTCARD_Receive(hsmartcard, rx_data, *nb_data, SMARTCARDx_TIMEOUT_MAX);
 
-	if(status != BSP_OK) {
+	switch(status){
+	case BSP_OK:
+		*nb_data = hsmartcard->RxXferSize;
+		break;
+	case BSP_TIMEOUT:
+		*nb_data = hsmartcard->RxXferSize - hsmartcard->RxXferCount - 1;
+		break;
+	case BSP_ERROR:
+	default:
+		*nb_data = 0;
 		smartcard_error(dev_num);
 	}
+
 	return status;
 }
 

--- a/src/drv/stm32cube/bsp_smartcard.h
+++ b/src/drv/stm32cube/bsp_smartcard.h
@@ -27,7 +27,7 @@ bsp_status_t bsp_smartcard_init(bsp_dev_smartcard_t dev_num, mode_config_proto_t
 bsp_status_t bsp_smartcard_deinit(bsp_dev_smartcard_t dev_num);
 
 bsp_status_t bsp_smartcard_write_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_data, uint8_t nb_data);
-bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data);
+bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data, uint32_t timeout);
 
 bsp_status_t bsp_smartcard_read_u8_timeout(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t nb_data, uint32_t timeout);
 bsp_status_t bsp_smartcard_write_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_data, uint8_t* rx_data, uint8_t nb_data);

--- a/src/drv/stm32cube/bsp_smartcard.h
+++ b/src/drv/stm32cube/bsp_smartcard.h
@@ -27,7 +27,7 @@ bsp_status_t bsp_smartcard_init(bsp_dev_smartcard_t dev_num, mode_config_proto_t
 bsp_status_t bsp_smartcard_deinit(bsp_dev_smartcard_t dev_num);
 
 bsp_status_t bsp_smartcard_write_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_data, uint8_t nb_data);
-bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t nb_data);
+bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data);
 
 bsp_status_t bsp_smartcard_read_u8_timeout(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t nb_data, uint32_t timeout);
 bsp_status_t bsp_smartcard_write_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_data, uint8_t* rx_data, uint8_t nb_data);

--- a/src/drv/stm32cube/bsp_smartcard.h
+++ b/src/drv/stm32cube/bsp_smartcard.h
@@ -29,7 +29,6 @@ bsp_status_t bsp_smartcard_deinit(bsp_dev_smartcard_t dev_num);
 bsp_status_t bsp_smartcard_write_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_data, uint8_t nb_data);
 bsp_status_t bsp_smartcard_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t *nb_data, uint32_t timeout);
 
-bsp_status_t bsp_smartcard_read_u8_timeout(bsp_dev_smartcard_t dev_num, uint8_t* rx_data, uint8_t nb_data, uint32_t timeout);
 bsp_status_t bsp_smartcard_write_read_u8(bsp_dev_smartcard_t dev_num, uint8_t* tx_data, uint8_t* rx_data, uint8_t nb_data);
 bsp_status_t bsp_smartcard_rxne(bsp_dev_smartcard_t dev_num);
 

--- a/src/drv/stm32cube/bsp_uart.c
+++ b/src/drv/stm32cube/bsp_uart.c
@@ -260,14 +260,23 @@ bsp_status_t bsp_uart_write_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t
   * @param  nb_data: Number of data to receive.
   * @retval status of the transfer.
   */
-bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t nb_data)
+bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data)
 {
 	UART_HandleTypeDef* huart;
 	huart = &uart_handle[dev_num];
 
 	bsp_status_t status;
-	status = (bsp_status_t) HAL_UART_Receive(huart, rx_data, nb_data, UARTx_TIMEOUT_MAX);
-	if(status != BSP_OK) {
+	status = (bsp_status_t) HAL_UART_Receive(huart, rx_data, *nb_data, 1000); //TODO: Change timeout value
+	switch(status){
+	case BSP_OK:
+		*nb_data = huart->RxXferSize;
+		break;
+	case BSP_TIMEOUT:
+		*nb_data = huart->RxXferSize - huart->RxXferCount - 1;
+		break;
+	case BSP_ERROR:
+	default:
+		*nb_data = 0;
 		uart_error(dev_num);
 	}
 	return status;

--- a/src/drv/stm32cube/bsp_uart.c
+++ b/src/drv/stm32cube/bsp_uart.c
@@ -258,15 +258,17 @@ bsp_status_t bsp_uart_write_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t
   * @param  dev_num: UART dev num.
   * @param  rx_data: Data to receive.
   * @param  nb_data: Number of data to receive.
-  * @retval status of the transfer.
+  * @param  timeout: Number of miliseconds to wait
+  * @retval status of the transfer. nb_data will contain the number of read
+  * bytes
   */
-bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data)
+bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data, uint32_t timeout)
 {
 	UART_HandleTypeDef* huart;
 	huart = &uart_handle[dev_num];
 
 	bsp_status_t status;
-	status = (bsp_status_t) HAL_UART_Receive(huart, rx_data, *nb_data, 1000); //TODO: Change timeout value
+	status = (bsp_status_t) HAL_UART_Receive(huart, rx_data, *nb_data, timeout);
 	switch(status){
 	case BSP_OK:
 		*nb_data = huart->RxXferSize;

--- a/src/drv/stm32cube/bsp_uart.c
+++ b/src/drv/stm32cube/bsp_uart.c
@@ -285,33 +285,6 @@ bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t 
 }
 
 /**
-  * @brief  Read bytes in blocking mode, with timeout
-  * @param  dev_num: UART dev num.
-  * @param  rx_data: Data to receive.
-  * @param  nb_data: Number of data to receive.
-  * @param  timeout: Number of ticks to wait
-  * @retval Number of bytes read
-  */
-bsp_status_t bsp_uart_read_u8_timeout(bsp_dev_uart_t dev_num, uint8_t* rx_data,
-				      uint8_t nb_data, uint32_t timeout)
-{
-	UART_HandleTypeDef* huart;
-	huart = &uart_handle[dev_num];
-
-	bsp_status_t status;
-	status = (bsp_status_t) HAL_UART_Receive(huart, rx_data, nb_data, timeout);
-	switch(status){
-	case BSP_OK:
-	case BSP_TIMEOUT:
-	    return (nb_data-(huart->RxXferCount)-1);
-	case BSP_ERROR:
-	default:
-		uart_error(dev_num);
-		return 0;
-	}
-}
-
-/**
   * @brief  Send a byte then Read a byte through the UART interface.
   * @param  tx_data: Data to send.
   * @param  rx_data: Data to receive.

--- a/src/drv/stm32cube/bsp_uart.h
+++ b/src/drv/stm32cube/bsp_uart.h
@@ -33,7 +33,7 @@ bsp_status_t bsp_uart_init(bsp_dev_uart_t dev_num, mode_config_proto_t* mode_con
 bsp_status_t bsp_uart_deinit(bsp_dev_uart_t dev_num);
 
 bsp_status_t bsp_uart_write_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t nb_data);
-bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data);
+bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data, uint32_t timeout);
 bsp_status_t bsp_uart_read_u8_timeout(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t nb_data, uint32_t timeout);
 bsp_status_t bsp_uart_write_read_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t* rx_data, uint8_t nb_data);
 bsp_status_t bsp_uart_rxne(bsp_dev_uart_t dev_num);

--- a/src/drv/stm32cube/bsp_uart.h
+++ b/src/drv/stm32cube/bsp_uart.h
@@ -34,7 +34,6 @@ bsp_status_t bsp_uart_deinit(bsp_dev_uart_t dev_num);
 
 bsp_status_t bsp_uart_write_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t nb_data);
 bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data, uint32_t timeout);
-bsp_status_t bsp_uart_read_u8_timeout(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t nb_data, uint32_t timeout);
 bsp_status_t bsp_uart_write_read_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t* rx_data, uint8_t nb_data);
 bsp_status_t bsp_uart_rxne(bsp_dev_uart_t dev_num);
 

--- a/src/drv/stm32cube/bsp_uart.h
+++ b/src/drv/stm32cube/bsp_uart.h
@@ -33,7 +33,7 @@ bsp_status_t bsp_uart_init(bsp_dev_uart_t dev_num, mode_config_proto_t* mode_con
 bsp_status_t bsp_uart_deinit(bsp_dev_uart_t dev_num);
 
 bsp_status_t bsp_uart_write_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t nb_data);
-bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t nb_data);
+bsp_status_t bsp_uart_read_u8(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t *nb_data);
 bsp_status_t bsp_uart_read_u8_timeout(bsp_dev_uart_t dev_num, uint8_t* rx_data, uint8_t nb_data, uint32_t timeout);
 bsp_status_t bsp_uart_write_read_u8(bsp_dev_uart_t dev_num, uint8_t* tx_data, uint8_t* rx_data, uint8_t nb_data);
 bsp_status_t bsp_uart_rxne(bsp_dev_uart_t dev_num);

--- a/src/hydrabus/commands.c
+++ b/src/hydrabus/commands.c
@@ -163,6 +163,7 @@ const t_token_dict tl_dict[] = {
 	{ T_CONVENTION, "convention" },
 	{ T_DELAY, "delay" },
 	{ T_CLOCK_STRETCH, "clock-stretch" },
+	{ T_TIMEOUT, "timeout" },
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */
@@ -475,6 +476,11 @@ t_token tokens_parity[] = {
 		T_STOP_BITS,\
 		.arg_type = T_ARG_UINT,\
 		.help = "Stop bits (1/2)"\
+	},\
+	{\
+		T_TIMEOUT,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Read timeout in msec"\
 	},
 
 t_token tokens_mode_uart[] = {
@@ -604,6 +610,11 @@ t_token tokens_uart[] = {
 		.arg_type = T_ARG_UINT,\
 		.help = "Communication convention",\
 		.help_full = "Set communication convention (0=normal, 1=inverse)"\
+	},\
+	{\
+		T_TIMEOUT,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Read timeout in msec"\
 	},
 
 t_token tokens_mode_smartcard[] = {
@@ -717,6 +728,11 @@ t_token tokens_smartcard[] = {
 		.arg_type = T_ARG_UINT,\
 		.help = "LIN device (1/2)"\
 	},\
+	{\
+		T_TIMEOUT,\
+		.arg_type = T_ARG_UINT,\
+		.help = "Read timeout in msec"\
+	},
 
 t_token tokens_mode_lin[] = {
 	{

--- a/src/hydrabus/commands.h
+++ b/src/hydrabus/commands.h
@@ -155,6 +155,7 @@ enum {
 	T_CONVENTION,
 	T_DELAY,
 	T_CLOCK_STRETCH,
+	T_TIMEOUT,
 	/* Developer warning add new command(s) here */
 
 	/* BP-compatible commands */

--- a/src/hydrabus/hydrabus_bbio_smartcard.c
+++ b/src/hydrabus/hydrabus_bbio_smartcard.c
@@ -59,6 +59,7 @@ void bbio_mode_smartcard(t_hydra_console *con)
 	uint8_t *tx_data = pool_alloc_bytes(0x1000); // 4096 bytes
 	uint8_t *rx_data = pool_alloc_bytes(0x1000); // 4096 bytes
 	uint8_t data, tmp;
+	uint8_t to_read;
 	uint32_t dev_speed=0;
 	uint32_t final_baudrate;
 	bsp_status_t status;
@@ -143,9 +144,10 @@ void bbio_mode_smartcard(t_hydra_console *con)
 				i=0;
 				while(i<to_rx) {
 					if((to_rx-i) >= 255) {
+						to_read = 255;
 						bsp_smartcard_read_u8(proto->dev_num,
 						                rx_data+i,
-						                &(uint8_t){255},
+						                &to_read,
 								TIME_MS2I(proto->timeout));
 					} else {
 						tmp = to_rx-i;
@@ -189,7 +191,8 @@ void bbio_mode_smartcard(t_hydra_console *con)
 				bsp_smartcard_set_rst(proto->dev_num, 0);
 				DelayMs(1);
 				bsp_smartcard_set_rst(proto->dev_num, 1);
-				bsp_smartcard_read_u8(proto->dev_num, rx_data, &(uint8_t){33}, TIME_MS2I(500));
+				to_read = 33;
+				bsp_smartcard_read_u8(proto->dev_num, rx_data, &to_read, TIME_MS2I(500));
 				cprint(con, (char *)&i, 1);
 				cprint(con, (char *)rx_data, i);
 				break;

--- a/src/hydrabus/hydrabus_bbio_smartcard.c
+++ b/src/hydrabus/hydrabus_bbio_smartcard.c
@@ -189,7 +189,7 @@ void bbio_mode_smartcard(t_hydra_console *con)
 				bsp_smartcard_set_rst(proto->dev_num, 0);
 				DelayMs(1);
 				bsp_smartcard_set_rst(proto->dev_num, 1);
-				bsp_smartcard_read_u8_timeout(proto->dev_num, rx_data, 33, TIME_MS2I(500));
+				bsp_smartcard_read_u8(proto->dev_num, rx_data, &(uint8_t){33}, TIME_MS2I(500));
 				cprint(con, (char *)&i, 1);
 				cprint(con, (char *)rx_data, i);
 				break;

--- a/src/hydrabus/hydrabus_bbio_smartcard.c
+++ b/src/hydrabus/hydrabus_bbio_smartcard.c
@@ -57,7 +57,7 @@ void bbio_mode_smartcard(t_hydra_console *con)
 	uint8_t bbio_subcommand;
 	uint8_t *tx_data = pool_alloc_bytes(0x1000); // 4096 bytes
 	uint8_t *rx_data = pool_alloc_bytes(0x1000); // 4096 bytes
-	uint8_t data;
+	uint8_t data, tmp;
 	uint32_t dev_speed=0;
 	uint32_t final_baudrate;
 	bsp_status_t status;
@@ -144,11 +144,12 @@ void bbio_mode_smartcard(t_hydra_console *con)
 					if((to_rx-i) >= 255) {
 						bsp_smartcard_read_u8(proto->dev_num,
 						                rx_data+i,
-						                255);
+						                &(uint8_t){255});
 					} else {
+						tmp = to_rx-i;
 						bsp_smartcard_read_u8(proto->dev_num,
 						                rx_data+i,
-						                to_rx-i);
+						                &tmp);
 					}
 					i+=255;
 				}

--- a/src/hydrabus/hydrabus_bbio_smartcard.c
+++ b/src/hydrabus/hydrabus_bbio_smartcard.c
@@ -35,6 +35,7 @@ void bbio_smartcard_init_proto_default(t_hydra_console *con)
 
 	/* Defaults */
 	proto->dev_num = 0;
+	proto->timeout = 10000;
 	proto->config.smartcard.dev_speed = 9600;
 	proto->config.smartcard.dev_parity = 0;
 	proto->config.smartcard.dev_stop_bit = 1;
@@ -144,12 +145,14 @@ void bbio_mode_smartcard(t_hydra_console *con)
 					if((to_rx-i) >= 255) {
 						bsp_smartcard_read_u8(proto->dev_num,
 						                rx_data+i,
-						                &(uint8_t){255});
+						                &(uint8_t){255},
+								TIME_MS2I(proto->timeout));
 					} else {
 						tmp = to_rx-i;
 						bsp_smartcard_read_u8(proto->dev_num,
 						                rx_data+i,
-						                &tmp);
+						                &tmp,
+								TIME_MS2I(proto->timeout));
 					}
 					i+=255;
 				}
@@ -186,7 +189,7 @@ void bbio_mode_smartcard(t_hydra_console *con)
 				bsp_smartcard_set_rst(proto->dev_num, 0);
 				DelayMs(1);
 				bsp_smartcard_set_rst(proto->dev_num, 1);
-				i = bsp_smartcard_read_u8_timeout(proto->dev_num, rx_data, 33, TIME_MS2I(500));
+				bsp_smartcard_read_u8_timeout(proto->dev_num, rx_data, 33, TIME_MS2I(500));
 				cprint(con, (char *)&i, 1);
 				cprint(con, (char *)rx_data, i);
 				break;

--- a/src/hydrabus/hydrabus_bbio_uart.c
+++ b/src/hydrabus/hydrabus_bbio_uart.c
@@ -54,10 +54,10 @@ static THD_FUNCTION(uart_reader_thread, arg)
 		if(!chThdShouldTerminateX())
 		{
 			if(bsp_uart_rxne(proto->dev_num)) {
-				bytes_read = bsp_uart_read_u8_timeout(proto->dev_num,
-											proto->buffer_rx,
-											UART_BRIDGE_BUFF_SIZE,
-											TIME_US2I(100));
+				bytes_read = bsp_uart_read_u8(proto->dev_num,
+							      proto->buffer_rx,
+							      &(uint8_t){UART_BRIDGE_BUFF_SIZE},
+							      TIME_US2I(100));
 				if(bytes_read > 0) {
 					cprint(con, (char *)proto->buffer_rx, bytes_read);
 				}

--- a/src/hydrabus/hydrabus_bbio_uart.c
+++ b/src/hydrabus/hydrabus_bbio_uart.c
@@ -34,6 +34,7 @@ void bbio_uart_init_proto_default(t_hydra_console *con)
 
 	/* Defaults */
 	proto->dev_num = 0;
+	proto->timeout = 10000;
 	proto->config.uart.dev_speed = 9600;
 	proto->config.uart.dev_parity = 0;
 	proto->config.uart.dev_stop_bit = 1;

--- a/src/hydrabus/hydrabus_bbio_uart.c
+++ b/src/hydrabus/hydrabus_bbio_uart.c
@@ -54,10 +54,11 @@ static THD_FUNCTION(uart_reader_thread, arg)
 		if(!chThdShouldTerminateX())
 		{
 			if(bsp_uart_rxne(proto->dev_num)) {
-				bytes_read = bsp_uart_read_u8(proto->dev_num,
-							      proto->buffer_rx,
-							      &(uint8_t){UART_BRIDGE_BUFF_SIZE},
-							      TIME_US2I(100));
+				bytes_read = UART_BRIDGE_BUFF_SIZE;
+				bsp_uart_read_u8(proto->dev_num,
+						 proto->buffer_rx,
+						 &bytes_read,
+						 TIME_US2I(100));
 				if(bytes_read > 0) {
 					cprint(con, (char *)proto->buffer_rx, bytes_read);
 				}

--- a/src/hydrabus/hydrabus_mode.c
+++ b/src/hydrabus/hydrabus_mode.c
@@ -102,6 +102,7 @@ const char hydrabus_mode_str_mul_read[] = "READ: ";
 const char hydrabus_mode_str_mul_value_u8[] = "0x%02X ";
 const char hydrabus_mode_str_mul_br[] = "\r\n";
 const char hydrabus_mode_str_mdelay[] = "DELAY: %lu ms\r\n";
+const char hydrabus_mode_str_read_timeout[] = "  TIMEOUT: read %lu out of %lu\r\n";
 
 static const char mode_str_write_error[] =  "WRITE error:%d\r\n";
 static const char mode_str_read_error[] = "READ error:%d\r\n";
@@ -233,7 +234,7 @@ int cmd_mode_exec(t_hydra_console *con, t_tokenline_parsed *p)
 				usec = 1;
 			}
 			DelayUs(usec);
-			break;            
+			break;
 		case T_PERCENT:
 			factor = 1000;
 			if (p->tokens[t + 1] == T_ARG_TOKEN_SUFFIX_INT) {
@@ -449,7 +450,7 @@ static int hydrabus_mode_read(t_hydra_console *con, t_tokenline_parsed *p,
 	if(con->mode->exec->read != NULL) {
 		mode_status = con->mode->exec->read(con, p_proto->buffer_rx, count);
 	}
-	if (mode_status != HYDRABUS_MODE_STATUS_OK)
+	if (mode_status == BSP_ERROR)
 		hydrabus_mode_read_error(con, mode_status);
 
 	return t - token_pos;

--- a/src/hydrabus/hydrabus_mode.h
+++ b/src/hydrabus/hydrabus_mode.h
@@ -69,7 +69,7 @@ typedef struct mode_exec_t {
 	/* Read data command 'read' or 'read:n' (return status 0=OK) */
 	uint32_t (*read)(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
 	/* Dump data */
-	uint32_t (*dump)(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data);
+	uint32_t (*dump)(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data);
 	/* Write & Read data (return status 0=OK) */
 	uint32_t (*write_read)(t_hydra_console *con, uint8_t *tx_data, uint8_t *rx_data, uint8_t nb_data);
 	/* Set CLK High (x-WIRE or other raw mode) command '/' */

--- a/src/hydrabus/hydrabus_mode.h
+++ b/src/hydrabus/hydrabus_mode.h
@@ -52,6 +52,9 @@ extern const char hydrabus_mode_str_mul_value_u8[];
 /* "\r\n" */
 extern const char hydrabus_mode_str_mul_br[];
 
+/* "TIMEOUT: read %lu out of %lu\r\n" */
+extern const char hydrabus_mode_str_read_timeout[];
+
 typedef struct mode_exec_t {
 	/* Initialize mode hardware. */
 	int (*init)(t_hydra_console *con, t_tokenline_parsed *p);

--- a/src/hydrabus/hydrabus_mode_i2c.c
+++ b/src/hydrabus/hydrabus_mode_i2c.c
@@ -294,13 +294,13 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return status;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint32_t status;
 	uint8_t i, tmp;
 	mode_config_proto_t* proto = &con->mode->proto;
 	status = BSP_ERROR;
-	for(i = 0; i < nb_data; i++) {
+	for(i = 0; i < *nb_data; i++) {
 		if(proto->config.i2c.ack_pending) {
 			/* Send I2C ACK */
 			status = bsp_i2c_read_ack(I2C_DEV_NUM, TRUE);

--- a/src/hydrabus/hydrabus_mode_jtag.c
+++ b/src/hydrabus/hydrabus_mode_jtag.c
@@ -959,12 +959,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint8_t i;
 
 	i = 0;
-	while(i < nb_data) {
+	while(i < *nb_data) {
 		rx_data[i] = jtag_read_u8(con);
 		i++;
 	}

--- a/src/hydrabus/hydrabus_mode_lin.c
+++ b/src/hydrabus/hydrabus_mode_lin.c
@@ -185,12 +185,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return status;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data, TIME_MS2I(proto->timeout));
 
 	return status;
 }

--- a/src/hydrabus/hydrabus_mode_lin.c
+++ b/src/hydrabus/hydrabus_mode_lin.c
@@ -22,6 +22,8 @@
 #include "hydrabus_trigger.h"
 #include <string.h>
 
+#define LIN_DEFAULT_TIMEOUT (10000)
+
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
 
@@ -42,6 +44,7 @@ static void init_proto_default(t_hydra_console *con)
 
 	/* Defaults */
 	proto->dev_num = 0;
+	proto->timeout = LIN_DEFAULT_TIMEOUT;
 	proto->config.uart.dev_speed = 9600;
 	proto->config.uart.bus_mode = BSP_UART_MODE_LIN;
 }
@@ -52,6 +55,8 @@ static void show_params(t_hydra_console *con)
 
 	cprintf(con, "Device: LIN%d\r\n",
 		proto->dev_num + 1);
+	cprintf(con, "Timeout: %d msec\r\n",
+				proto->timeout);
 }
 
 static int init(t_hydra_console *con, t_tokenline_parsed *p)
@@ -107,6 +112,16 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 			tl_set_prompt(con->tl, (char *)con->mode->exec->get_prompt(con));
 			cprintf(con, "Note: LIN parameters have been reset to default values.\r\n");
 			break;
+		case T_TIMEOUT:
+			/* Integer parameter. */
+			t += 2;
+			memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+			if (arg_int < 1 || arg_int > 30000) {
+				cprintf(con, "Timeout value must be set between 1 and 30000.\r\n");
+				return t;
+			}
+			proto->timeout = arg_int;
+			break;
 		case T_TRIGGER:
 			t++;
 			t += cmd_trigger(con, p, t);
@@ -149,7 +164,7 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	mode_config_proto_t* proto = &con->mode->proto;
 	uint8_t orig_nb_data = nb_data;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data);
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
 	switch(status) {
 	case BSP_TIMEOUT:
 		cprintf(con, hydrabus_mode_str_read_timeout, nb_data, orig_nb_data);
@@ -175,7 +190,7 @@ static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data);
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
 
 	return status;
 }

--- a/src/hydrabus/hydrabus_mode_lin.c
+++ b/src/hydrabus/hydrabus_mode_lin.c
@@ -147,9 +147,14 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	int i;
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
+	uint8_t orig_nb_data = nb_data;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data);
-	if(status == BSP_OK) {
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data);
+	switch(status) {
+	case BSP_TIMEOUT:
+		cprintf(con, hydrabus_mode_str_read_timeout, nb_data, orig_nb_data);
+		__attribute__ ((fallthrough)); // Explicitly fall through
+	case BSP_OK:
 		if(nb_data == 1) {
 			/* Read 1 data */
 			cprintf(con, hydrabus_mode_str_read_one_u8, rx_data[0]);
@@ -170,7 +175,7 @@ static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data);
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data);
 
 	return status;
 }

--- a/src/hydrabus/hydrabus_mode_lin.c
+++ b/src/hydrabus/hydrabus_mode_lin.c
@@ -22,7 +22,7 @@
 #include "hydrabus_trigger.h"
 #include <string.h>
 
-#define LIN_DEFAULT_TIMEOUT (10000)
+#define LIN_DEFAULT_TIMEOUT (2000)
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);

--- a/src/hydrabus/hydrabus_mode_onewire.c
+++ b/src/hydrabus/hydrabus_mode_onewire.c
@@ -472,12 +472,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint8_t i;
 
 	i = 0;
-	while(i < nb_data) {
+	while(i < *nb_data) {
 		rx_data[i] = onewire_read_u8(con);
 		i++;
 	}

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -166,7 +166,8 @@ static void smartcard_get_atr(t_hydra_console *con)
 		/* We don't care about the convention since the TS is not
 		 * standard
 		 */
-		atr_size = bsp_smartcard_read_u8_timeout(proto->dev_num, &atr[1], 8, TIME_MS2I(100));
+		atr_size = 8;
+		atr_size = bsp_smartcard_read_u8(proto->dev_num, &atr[1], &atr_size, TIME_MS2I(100));
 		print_hex(con, atr, atr_size);
 		return;
 	}

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -133,6 +133,7 @@ static void smartcard_get_atr(t_hydra_console *con)
 	uint8_t D = 0;
 	uint16_t E = 0;
 	uint8_t max = 0;
+	uint8_t to_read = 0;
 
 	/* Defaults */
 	init_proto_default(con);
@@ -142,10 +143,12 @@ static void smartcard_get_atr(t_hydra_console *con)
 	DelayMs(1);							// RST low for at least 400 clocks (tb).
 	bsp_smartcard_set_vcc(proto->dev_num, 0);
 	bsp_smartcard_set_rst(proto->dev_num, 1);
-	bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1}, TIME_MS2I(proto->timeout));
+	to_read = 1;
+	bsp_smartcard_read_u8(proto->dev_num, atr, &to_read, TIME_MS2I(proto->timeout));
 
 	if (atr[0] == 0) {
-		bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1}, TIME_MS2I(proto->timeout));
+		to_read = 1;
+		bsp_smartcard_read_u8(proto->dev_num, atr, &to_read, TIME_MS2I(proto->timeout));
 	}
 
 	/* Inverse or Direct convention */
@@ -172,7 +175,8 @@ static void smartcard_get_atr(t_hydra_console *con)
 		return;
 	}
 
-	bsp_smartcard_read_u8(proto->dev_num, atr+1, &(uint8_t){1}, TIME_MS2I(proto->timeout));
+	to_read = 1;
+	bsp_smartcard_read_u8(proto->dev_num, atr+1, &to_read, TIME_MS2I(proto->timeout));
 	apply_convention(con, atr+1, 1);
 
 	while(more_td) {
@@ -185,7 +189,8 @@ static void smartcard_get_atr(t_hydra_console *con)
 			checksum |= atr[r]&0x1;
 		r++;
 		for(; r<=atr_size; r++) {
-			bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1}, TIME_MS2I(proto->timeout));
+			to_read = 1;
+			bsp_smartcard_read_u8(proto->dev_num, atr+r, &to_read, TIME_MS2I(proto->timeout));
 			apply_convention(con, atr+r, 1);
 
 			// Test if TA1 is present from T0,
@@ -216,20 +221,23 @@ static void smartcard_get_atr(t_hydra_console *con)
 
 	/* Read last Ti */
 	for(; r<=atr_size; r++) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1}, TIME_MS2I(proto->timeout));
+		to_read = 1;
+		bsp_smartcard_read_u8(proto->dev_num, atr+r, &to_read, TIME_MS2I(proto->timeout));
 		apply_convention(con, atr+r, 1);
 	}
 
 	/* Read historical data */
 	for(i=0; i<(atr[1] & 0x0f); i++) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+(r+i), &(uint8_t){1}, TIME_MS2I(proto->timeout));
+		to_read = 1;
+		bsp_smartcard_read_u8(proto->dev_num, atr+(r+i), &to_read, TIME_MS2I(proto->timeout));
 		apply_convention(con, atr+(r+i), 1);
 	}
 	r+=i;
 
 	/* Read checksum if present and print ATR */
 	if(checksum) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1}, TIME_MS2I(proto->timeout));
+		to_read = 1;
+		bsp_smartcard_read_u8(proto->dev_num, atr+r, &to_read, TIME_MS2I(proto->timeout));
 		apply_convention(con, atr+r, 1);
 		print_hex(con, atr, r+1);
 	} else {

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -23,6 +23,7 @@
 #include <string.h>
 
 #define SMARTCARD_DEFAULT_SPEED (9408)
+#define SMARTCARD_DEFAULT_TIMEOUT (10000)
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);
@@ -55,6 +56,7 @@ static void init_proto_default(t_hydra_console *con)
 
 	/* Defaults */
 	proto->dev_num = 0;
+	proto->timeout = SMARTCARD_DEFAULT_TIMEOUT;
 	proto->config.smartcard.dev_speed = SMARTCARD_DEFAULT_SPEED;
 	proto->config.smartcard.dev_parity = 0;
 	proto->config.smartcard.dev_stop_bit = 1;
@@ -83,6 +85,8 @@ static void show_params(t_hydra_console *con)
 		proto->config.smartcard.dev_prescaler);
 	print_freq(con, bsp_smartcard_get_clk_frequency(proto->dev_num));
 	cprint(con, "\r\n", 2);
+	cprintf(con, "Timeout: %d msec\r\n",
+				proto->timeout);
 }
 
 static int init(t_hydra_console *con, t_tokenline_parsed *p)
@@ -138,10 +142,10 @@ static void smartcard_get_atr(t_hydra_console *con)
 	DelayMs(1);							// RST low for at least 400 clocks (tb).
 	bsp_smartcard_set_vcc(proto->dev_num, 0);
 	bsp_smartcard_set_rst(proto->dev_num, 1);
-	bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1});
+	bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1}, TIME_MS2I(proto->timeout));
 
 	if (atr[0] == 0) {
-		bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1});
+		bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1}, TIME_MS2I(proto->timeout));
 	}
 
 	/* Inverse or Direct convention */
@@ -167,7 +171,7 @@ static void smartcard_get_atr(t_hydra_console *con)
 		return;
 	}
 
-	bsp_smartcard_read_u8(proto->dev_num, atr+1, &(uint8_t){1});
+	bsp_smartcard_read_u8(proto->dev_num, atr+1, &(uint8_t){1}, TIME_MS2I(proto->timeout));
 	apply_convention(con, atr+1, 1);
 
 	while(more_td) {
@@ -180,7 +184,7 @@ static void smartcard_get_atr(t_hydra_console *con)
 			checksum |= atr[r]&0x1;
 		r++;
 		for(; r<=atr_size; r++) {
-			bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1});
+			bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1}, TIME_MS2I(proto->timeout));
 			apply_convention(con, atr+r, 1);
 
 			// Test if TA1 is present from T0,
@@ -211,20 +215,20 @@ static void smartcard_get_atr(t_hydra_console *con)
 
 	/* Read last Ti */
 	for(; r<=atr_size; r++) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1});
+		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1}, TIME_MS2I(proto->timeout));
 		apply_convention(con, atr+r, 1);
 	}
 
 	/* Read historical data */
 	for(i=0; i<(atr[1] & 0x0f); i++) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+(r+i), &(uint8_t){1});
+		bsp_smartcard_read_u8(proto->dev_num, atr+(r+i), &(uint8_t){1}, TIME_MS2I(proto->timeout));
 		apply_convention(con, atr+(r+i), 1);
 	}
 	r+=i;
 
 	/* Read checksum if present and print ATR */
 	if(checksum) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1});
+		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1}, TIME_MS2I(proto->timeout));
 		apply_convention(con, atr+r, 1);
 		print_hex(con, atr, r+1);
 	} else {
@@ -424,6 +428,16 @@ static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 				return t;
 			}
 			break;
+		case T_TIMEOUT:
+			/* Integer parameter. */
+			t += 2;
+			memcpy(&arg_int, p->buf + p->tokens[t], sizeof(int));
+			if (arg_int < 1 || arg_int > 30000) {
+				cprintf(con, "Timeout value must be set between 1 and 30000.\r\n");
+				return t;
+			}
+			proto->timeout = arg_int;
+			break;
 		case T_QUERY:
 			smartcard_get_card_status(con);
 			break;
@@ -469,7 +483,7 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	mode_config_proto_t* proto = &con->mode->proto;
 	uint8_t orig_nb_data = nb_data;
 
-	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data);
+	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
 	apply_convention(con, rx_data, nb_data);
 	switch(status) {
 	case BSP_TIMEOUT:
@@ -496,7 +510,7 @@ static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data);
+	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
 	apply_convention(con, rx_data, nb_data);
 
 	return status;

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -506,13 +506,13 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return status;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
-	apply_convention(con, rx_data, nb_data);
+	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, nb_data, TIME_MS2I(proto->timeout));
+	apply_convention(con, rx_data, *nb_data);
 
 	return status;
 }

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -23,7 +23,7 @@
 #include <string.h>
 
 #define SMARTCARD_DEFAULT_SPEED (9408)
-#define SMARTCARD_DEFAULT_TIMEOUT (10000)
+#define SMARTCARD_DEFAULT_TIMEOUT (1000)
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);

--- a/src/hydrabus/hydrabus_mode_smartcard.c
+++ b/src/hydrabus/hydrabus_mode_smartcard.c
@@ -138,10 +138,10 @@ static void smartcard_get_atr(t_hydra_console *con)
 	DelayMs(1);							// RST low for at least 400 clocks (tb).
 	bsp_smartcard_set_vcc(proto->dev_num, 0);
 	bsp_smartcard_set_rst(proto->dev_num, 1);
-	bsp_smartcard_read_u8(proto->dev_num, atr, 1);
+	bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1});
 
 	if (atr[0] == 0) {
-		bsp_smartcard_read_u8(proto->dev_num, atr, 1);
+		bsp_smartcard_read_u8(proto->dev_num, atr, &(uint8_t){1});
 	}
 
 	/* Inverse or Direct convention */
@@ -167,7 +167,7 @@ static void smartcard_get_atr(t_hydra_console *con)
 		return;
 	}
 
-	bsp_smartcard_read_u8(proto->dev_num, atr+1, 1);
+	bsp_smartcard_read_u8(proto->dev_num, atr+1, &(uint8_t){1});
 	apply_convention(con, atr+1, 1);
 
 	while(more_td) {
@@ -180,7 +180,7 @@ static void smartcard_get_atr(t_hydra_console *con)
 			checksum |= atr[r]&0x1;
 		r++;
 		for(; r<=atr_size; r++) {
-			bsp_smartcard_read_u8(proto->dev_num, atr+r, 1);
+			bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1});
 			apply_convention(con, atr+r, 1);
 
 			// Test if TA1 is present from T0,
@@ -211,20 +211,20 @@ static void smartcard_get_atr(t_hydra_console *con)
 
 	/* Read last Ti */
 	for(; r<=atr_size; r++) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+r, 1);
+		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1});
 		apply_convention(con, atr+r, 1);
 	}
 
 	/* Read historical data */
 	for(i=0; i<(atr[1] & 0x0f); i++) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+(r+i), 1);
+		bsp_smartcard_read_u8(proto->dev_num, atr+(r+i), &(uint8_t){1});
 		apply_convention(con, atr+(r+i), 1);
 	}
 	r+=i;
 
 	/* Read checksum if present and print ATR */
 	if(checksum) {
-		bsp_smartcard_read_u8(proto->dev_num, atr+r, 1);
+		bsp_smartcard_read_u8(proto->dev_num, atr+r, &(uint8_t){1});
 		apply_convention(con, atr+r, 1);
 		print_hex(con, atr, r+1);
 	} else {
@@ -467,10 +467,15 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	int i;
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
+	uint8_t orig_nb_data = nb_data;
 
-	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, nb_data);
+	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data);
 	apply_convention(con, rx_data, nb_data);
-	if(status == BSP_OK) {
+	switch(status) {
+	case BSP_TIMEOUT:
+		cprintf(con, hydrabus_mode_str_read_timeout, nb_data, orig_nb_data);
+		__attribute__ ((fallthrough)); // Explicitly fall through
+	case BSP_OK:
 		if(nb_data == 1) {
 			/* Read 1 data */
 			cprintf(con, hydrabus_mode_str_read_one_u8, rx_data[0]);
@@ -491,7 +496,7 @@ static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, nb_data);
+	status = bsp_smartcard_read_u8(proto->dev_num, rx_data, &nb_data);
 	apply_convention(con, rx_data, nb_data);
 
 	return status;

--- a/src/hydrabus/hydrabus_mode_spi.c
+++ b/src/hydrabus/hydrabus_mode_spi.c
@@ -312,12 +312,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return status;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_spi_read_u8(proto->dev_num, rx_data, nb_data);
+	status = bsp_spi_read_u8(proto->dev_num, rx_data, *nb_data);
 	return status;
 }
 

--- a/src/hydrabus/hydrabus_mode_threewire.c
+++ b/src/hydrabus/hydrabus_mode_threewire.c
@@ -403,12 +403,12 @@ static uint32_t write_read(t_hydra_console *con, uint8_t *tx_data, uint8_t *rx_d
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint8_t i;
 
 	i = 0;
-	while(i < nb_data){
+	while(i < *nb_data){
 		rx_data[i] = threewire_read_u8(con);
 		i++;
 	}

--- a/src/hydrabus/hydrabus_mode_twowire.c
+++ b/src/hydrabus/hydrabus_mode_twowire.c
@@ -488,12 +488,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return BSP_OK;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint8_t i;
 
 	i = 0;
-	while(i < nb_data){
+	while(i < *nb_data){
 		rx_data[i] = twowire_read_u8(con);
 		i++;
 	}

--- a/src/hydrabus/hydrabus_mode_uart.c
+++ b/src/hydrabus/hydrabus_mode_uart.c
@@ -290,9 +290,14 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	int i;
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
+	uint8_t orig_nb_data = nb_data;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data);
-	if(status == BSP_OK) {
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data);
+	switch(status) {
+	case BSP_TIMEOUT:
+		cprintf(con, hydrabus_mode_str_read_timeout, nb_data, orig_nb_data);
+		__attribute__ ((fallthrough)); // Explicitly fall through
+	case BSP_OK:
 		if(nb_data == 1) {
 			/* Read 1 data */
 			cprintf(con, hydrabus_mode_str_read_one_u8, rx_data[0]);
@@ -313,7 +318,7 @@ static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data);
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data);
 
 	return status;
 }

--- a/src/hydrabus/hydrabus_mode_uart.c
+++ b/src/hydrabus/hydrabus_mode_uart.c
@@ -327,12 +327,12 @@ static uint32_t read(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
 	return status;
 }
 
-static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t nb_data)
+static uint32_t dump(t_hydra_console *con, uint8_t *rx_data, uint8_t *nb_data)
 {
 	uint32_t status;
 	mode_config_proto_t* proto = &con->mode->proto;
 
-	status = bsp_uart_read_u8(proto->dev_num, rx_data, &nb_data, TIME_MS2I(proto->timeout));
+	status = bsp_uart_read_u8(proto->dev_num, rx_data, nb_data, TIME_MS2I(proto->timeout));
 
 	return status;
 }

--- a/src/hydrabus/hydrabus_mode_uart.c
+++ b/src/hydrabus/hydrabus_mode_uart.c
@@ -23,7 +23,7 @@
 #include <string.h>
 
 #define UART_DEFAULT_SPEED (9600)
-#define UART_DEFAULT_TIMEOUT (10000)
+#define UART_DEFAULT_TIMEOUT (2000)
 
 static int exec(t_hydra_console *con, t_tokenline_parsed *p, int token_pos);
 static int show(t_hydra_console *con, t_tokenline_parsed *p);

--- a/src/hydrabus/hydrabus_mode_uart.c
+++ b/src/hydrabus/hydrabus_mode_uart.c
@@ -101,10 +101,11 @@ static THD_FUNCTION(bridge_thread, arg)
 
 	while (!hydrabus_ubtn()) {
 		if(bsp_uart_rxne(proto->dev_num)) {
-			bytes_read = bsp_uart_read_u8(proto->dev_num,
-						      proto->buffer_rx,
-						      &(uint8_t){UART_BRIDGE_BUFF_SIZE},
-						      TIME_US2I(100));
+			bytes_read = UART_BRIDGE_BUFF_SIZE;
+			bsp_uart_read_u8(proto->dev_num,
+					 proto->buffer_rx,
+					 &bytes_read,
+					 TIME_US2I(100));
 			if(bytes_read > 0) {
 				cprint(con, (char *)proto->buffer_rx, bytes_read);
 			}

--- a/src/hydrabus/hydrabus_mode_uart.c
+++ b/src/hydrabus/hydrabus_mode_uart.c
@@ -101,10 +101,10 @@ static THD_FUNCTION(bridge_thread, arg)
 
 	while (!hydrabus_ubtn()) {
 		if(bsp_uart_rxne(proto->dev_num)) {
-			bytes_read = bsp_uart_read_u8_timeout(proto->dev_num,
-							      proto->buffer_rx,
-							      UART_BRIDGE_BUFF_SIZE,
-							      TIME_US2I(100));
+			bytes_read = bsp_uart_read_u8(proto->dev_num,
+						      proto->buffer_rx,
+						      &(uint8_t){UART_BRIDGE_BUFF_SIZE},
+						      TIME_US2I(100));
 			if(bytes_read > 0) {
 				cprint(con, (char *)proto->buffer_rx, bytes_read);
 			}

--- a/src/hydrabus/hydrabus_trigger.c
+++ b/src/hydrabus/hydrabus_trigger.c
@@ -59,11 +59,12 @@ static int show(t_hydra_console *con, t_tokenline_parsed *p, int token_pos)
 static int trigger_run(t_hydra_console *con)
 {
 	uint32_t i=0;
-	uint8_t rx_data;
+	uint8_t rx_data, to_read;
 	bsp_trigger_init();
 	while(!hydrabus_ubtn()) {
 		if(con->mode->exec->read) {
-			con->mode->exec->dump(con,&rx_data,&(uint8_t){1});
+			to_read = 1;
+			con->mode->exec->dump(con,&rx_data,&to_read);
 		}
 		if(rx_data == trigger_data[i]) {
 			i++;

--- a/src/hydrabus/hydrabus_trigger.c
+++ b/src/hydrabus/hydrabus_trigger.c
@@ -63,7 +63,7 @@ static int trigger_run(t_hydra_console *con)
 	bsp_trigger_init();
 	while(!hydrabus_ubtn()) {
 		if(con->mode->exec->read) {
-			con->mode->exec->dump(con,&rx_data,1);
+			con->mode->exec->dump(con,&rx_data,&(uint8_t){1});
 		}
 		if(rx_data == trigger_data[i]) {
 			i++;


### PR DESCRIPTION
Based on #164 this PR adds a read with timeout feature.

1) Add a `timeout` keyword to set timeout in miliseconds on all relevant modes (UART, LIN, Smartcard)
2) Change `read` and `hd` commands behavior. They now display read bytes and show an message if not every byte requested could be read
3) Some cleanup of now unused functions

Example with UART in loopback mode:
```
> uart 
Device: UART1
Speed: 9600 bps
Parity: none
Stop bits: 1
Timeout: 10000 msec
uart1> timeout 1000
uart1> show 
Device: UART1
Speed: 9600 bps
Parity: none
Stop bits: 1
Timeout: 1000 msec
uart1> 0x41 r:8
WRITE: 0x41
! TIMEOUT: read 1 out of 8
READ: 0x41
uart1> 0x41 hd:8
WRITE: 0x41
41                                                |  A 
! TIMEOUT: read 1 out of 8
uart1>
```

This might need to be further tested before being included. Maybe @bvernoux and @0xDRRB could do some tests ?