### PR TITLE
CI/CD basic implementation based on GitHub Actions

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           submodules: true
           fetch-tags: true
-          fetch-branches: true
           fetch-depth: 0
 
       - name: Set git meta info

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -41,7 +41,7 @@ jobs:
         run: bash  scripts/env.sh
 
       - name: Build ${{ matrix.model }}
-        run: source  build.env  &&  arm-none-eabi-gcc --version  &&  arm-none-eabi-gcc -print-search-dirs  &&  python3  src/build-scripts/hydrafw-revision.py  &&  make  V=1  -j$(nproc)  -C src/
+        run: source  build.env  &&  arm-none-eabi-gcc --version  &&  arm-none-eabi-gcc -print-search-dirs  &&  make  V=1  -j$(nproc)  -C src/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           submodules: true
           fetch-tags: true
+          fetch-branches: true
           fetch-depth: 0
 
       - name: Set git meta info

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
         run: sudo  apt  update  -y
 
       - name: Install packages
-        run: sudo  apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3  python3-pip
+        run: sudo  apt  install  -y  --no-install-recommends  --no-install-suggests  bash  coreutils  tar  bzip2  git  make  python3  python3-pip
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,8 +32,6 @@ jobs:
         run: python3  -m pip  install  GitPython intelhex  --upgrade
 
       - uses: actions/checkout@v3
-        with:
-          submodules: true
 
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade
 
+      - name: Install standalone reference GCC toolchain
+        run: bash  scripts/env.sh
+
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -41,7 +44,7 @@ jobs:
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
-        run: make  -j$(nproc)  -C src/
+        run: source  build.env  &&  make  -j$(nproc)  -C src/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,14 +30,11 @@ jobs:
         with:
           submodules: true
 
-      - name: Git ownership exception
-        run: git config --global --add safe.directory /home/runner/work/hydrafw/hydrafw && git config --global safe.directory "$GITHUB_WORKSPACE"
-
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: DEBUGGING
-        run: echo "FW_REVISION" && python3 build-scripts/hydrafw-revision.py && echo "DONE"
+        run: echo "FW_REVISION" && cd  src  &&  python3 build-scripts/hydrafw-revision.py && echo "DONE"
 
       - name: DEBUGGING2
         run: git tag --points-at ${GITHUB_CI_PR_SHA} || true

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
         run: apt  update  -y
 
       - name: Install packages
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install dependencies (python)
         run: python3  -m pip  install  GitPython intelhex  --upgrade
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           submodules: true
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
         run: cat /etc/apt/sources.list  &&  apt  update  -y
 
       - name: Install dependencies
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install dependencies (python)
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       image: debian:oldstable
     strategy:
       matrix:
-        model: "hydrafw"
+        model: [ "hydrafw" ]
       fail-fast: true
 
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade
 
-      - name: Install standalone reference GCC toolchain
-        run: bash  scripts/env.sh
-
       - uses: actions/checkout@v4
         with:
           submodules: true
@@ -40,6 +37,9 @@ jobs:
 
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
+
+      - name: Install standalone reference GCC toolchain
+        run: bash  scripts/env.sh
 
       - name: Build ${{ matrix.model }}
         run: source  build.env  &&  make  V=1  -j$(nproc)  -C src/

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -47,7 +47,7 @@ jobs:
         with:
           name: ${{ matrix.model }}
           path: |
-            build/${{ matrix.model }}.dfu
+            src/build/${{ matrix.model }}.dfu
           if-no-files-found: error
 
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,9 @@ jobs:
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
+      - name: Git submodules
+        run: git  submodule  update  --init  --recursive
+
       - name: DEBUGGING
         run: echo "FW_REVISION" && cd  src  &&  python3 build-scripts/hydrafw-revision.py && echo "DONE"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         run: apt  update  -y
 
       - name: Install packages
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3  python3-pip
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,10 +17,7 @@ jobs:
       image: debian:oldstable
     strategy:
       matrix:
-        model:
-          [
-            "hydrafw",
-          ]
+        model: hydrafw
       fail-fast: true
 
     steps:
@@ -38,13 +35,13 @@ jobs:
           submodules: true
 
       - name: Set git ownership
-        run: git config --global --add safe.directory /__w/hydrafw/hydrafw
+        run: git  config  --global  --add safe.directory /__w/hydrafw/hydrafw
 
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
-        run: python3 src/build-scripts/hydrafw-revision.py  &&  cd  src  &&  make  clean  &&  make  -j$(nproc)
+        run: make  -j$(nproc)  -C src/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,6 +31,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-tags: true
 
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
@@ -39,7 +40,7 @@ jobs:
         run: bash  scripts/env.sh
 
       - name: Build ${{ matrix.model }}
-        run: source  build.env  &&  arm-none-eabi-gcc --version  &&  arm-none-eabi-gcc -print-search-dirs  &&  make  V=1  -j$(nproc)  -C src/
+        run: source  build.env  &&  arm-none-eabi-gcc --version  &&  arm-none-eabi-gcc -print-search-dirs  &&  python3  src/build-scripts/hydrafw-revision.py  &&  make  V=1  -j$(nproc)  -C src/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: true
 
       - name: Git ownership exception
-        run: ls -la / ; ls -la /__w/ ; git config --global --add safe.directory /__w/hydrabus/hydrafw && git config --global safe.directory "$GITHUB_WORKSPACE"
+        run: git config --global --add safe.directory /home/runner/work/hydrafw/hydrafw && git config --global safe.directory "$GITHUB_WORKSPACE"
 
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,9 @@ jobs:
       fail-fast: true
 
     steps:
+      - name: Configure apt
+        run: add-apt-repository  universe  &&  add-apt-repository multiverse  &&  add-apt-repository restricted  &&  apt  update
+
       - name: Install dependencies
         run: apt  install  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
+      - name: DEBUGGING
+        run: echo "FW_REVISION" && python3 build-scripts/hydrafw-revision.py && echo "DONE"
+
+      - name: DEBUGGING2
+        run: git tag --points-at ${GITHUB_CI_PR_SHA} || true
+
       - name: Build ${{ matrix.model }}
         run: cd  src  &&  make  clean  &&  make  -j$(nproc)
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Install dependencies
-        run: sudo  apt  install  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install dependencies (python)
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -25,7 +25,7 @@ jobs:
         run: apt  update  -y
 
       - name: Install packages
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -42,7 +42,7 @@ jobs:
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
-        run: source  build.env  &&  make  -j$(nproc)  -C src/
+        run: source  build.env  &&  make  V=1  -j$(nproc)  -C src/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -39,7 +39,7 @@ jobs:
         run: bash  scripts/env.sh
 
       - name: Build ${{ matrix.model }}
-        run: source  build.env  &&  make  V=1  -j$(nproc)  -C src/
+        run: source  build.env  &&  arm-none-eabi-gcc --version  &&  arm-none-eabi-gcc -print-search-dirs  &&  make  V=1  -j$(nproc)  -C src/
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,10 +23,10 @@ jobs:
 
     steps:
       - name: Configure apt
-        run: cat /etc/apt/sources.list  &&  apt  update
+        run: cat /etc/apt/sources.list  &&  apt  update  -y
 
       - name: Install dependencies
-        run: apt  install  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install dependencies (python)
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,9 +32,6 @@ jobs:
         with:
           submodules: true
 
-      - name: Set git ownership
-        run: git  config  --global  --add safe.directory /__w/hydrafw/hydrafw
-
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: ubuntu:18.04
+      image: debian:oldstable
     strategy:
       matrix:
         model:
@@ -31,7 +31,9 @@ jobs:
       - name: Install dependencies (python)
         run: python3  -m pip  install  GitPython intelhex  --upgrade
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
 
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   build:
-    runs-on: debian-oldstable
+    runs-on: ubuntu-22.04
+    container:
+      image: debian:oldstable
     strategy:
       matrix:
         model:
@@ -21,10 +23,10 @@ jobs:
 
     steps:
       - name: Update package cache
-        run: sudo  apt  update  -y
+        run: apt  update  -y
 
       - name: Install packages
-        run: sudo  apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade
@@ -32,6 +34,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
+
+      - name: Set git ownership
+        run: git config --global --add safe.directory /__w/hydrafw/hydrafw
 
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -17,7 +17,7 @@ jobs:
       image: debian:oldstable
     strategy:
       matrix:
-        model: hydrafw
+        model: "hydrafw"
       fail-fast: true
 
     steps:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,7 +28,7 @@ jobs:
         run: apt  update  -y
 
       - name: Install packages
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,11 +35,11 @@ jobs:
         with:
           submodules: true
 
+      - name: Git ownership
+        run: git config --global --add safe.directory /__w/hydrafw/hydrafw
+
       - name: Git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
-
-      - name: Git submodules
-        run: git  submodule  update  --init  --recursive
 
       - name: DEBUGGING
         run: echo "FW_REVISION" && cd  src  &&  python3 build-scripts/hydrafw-revision.py && echo "DONE"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,30 +22,24 @@ jobs:
       fail-fast: true
 
     steps:
-      - name: Configure apt
-        run: cat /etc/apt/sources.list  &&  apt  update  -y
+      - name: Update package cache
+        run: apt  update  -y
 
-      - name: Install dependencies
+      - name: Install packages
         run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
-      - name: Install dependencies (python)
+      - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade
 
       - uses: actions/checkout@v4
         with:
           submodules: true
 
-      - name: Git ownership
+      - name: Set git ownership
         run: git config --global --add safe.directory /__w/hydrafw/hydrafw
 
-      - name: Git meta info
+      - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
-
-      - name: DEBUGGING
-        run: echo "FW_REVISION" && cd  src  &&  python3 build-scripts/hydrafw-revision.py && echo "DONE"
-
-      - name: DEBUGGING2
-        run: git tag --points-at ${GITHUB_CI_PR_SHA} || true
 
       - name: Build ${{ matrix.model }}
         run: cd  src  &&  make  clean  &&  make  -j$(nproc)

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,6 +24,9 @@ jobs:
       fail-fast: true
 
     steps:
+      - name: Update package cache
+        run: apt  update  -y
+
       - name: Install packages
         run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,9 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
+    container:
+      image: ubuntu:18.04
     strategy:
       matrix:
         model:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Configure apt
-        run: add-apt-repository  universe  &&  add-apt-repository multiverse  &&  add-apt-repository restricted  &&  apt  update
+        run: cat /etc/apt/sources.list  &&  apt  update
 
       - name: Install dependencies
         run: apt  install  --no-install-recommends  --no-install-suggests  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,9 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
-    container:
-      image: debian:oldstable
+    runs-on: debian-oldstable
     strategy:
       matrix:
         model:
@@ -23,10 +21,10 @@ jobs:
 
     steps:
       - name: Update package cache
-        run: apt  update  -y
+        run: sudo  apt  update  -y
 
       - name: Install packages
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: sudo  apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade
@@ -34,9 +32,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: true
-
-      - name: Set git ownership
-        run: git config --global --add safe.directory /__w/hydrafw/hydrafw
 
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -13,8 +13,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-22.04
-    container:
-      image: debian:oldstable
     strategy:
       matrix:
         model: [ "hydrafw" ]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           submodules: true
           fetch-tags: true
+          fetch-depth: 0
 
       - name: Set git meta info
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -24,9 +24,6 @@ jobs:
       fail-fast: true
 
     steps:
-      - name: Update package cache
-        run: apt  update  -y
-
       - name: Install packages
         run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,7 +26,7 @@ jobs:
         run: cat /etc/apt/sources.list  &&  apt  update  -y
 
       - name: Install dependencies
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
+        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3-pip  gcc-arm-none-eabi  libnewlib-arm-none-eabi  libstdc++-arm-none-eabi-newlib
 
       - name: Install dependencies (python)
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-18.04
     strategy:
       matrix:
         model:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -20,10 +20,10 @@ jobs:
 
     steps:
       - name: Update package cache
-        run: apt  update  -y
+        run: sudo  apt  update  -y
 
       - name: Install packages
-        run: apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3  python3-pip
+        run: sudo  apt  install  -y  --no-install-recommends  --no-install-suggests  git  make  python3  python3-pip
 
       - name: Install python modules
         run: python3  -m pip  install  GitPython intelhex  --upgrade

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,5 +1,6 @@
 name: CI
 
+
 on:
   push:
     branches:
@@ -7,6 +8,7 @@ on:
   pull_request:
     branches:
       - master
+
 
 jobs:
   build:
@@ -42,7 +44,7 @@ jobs:
         run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
 
       - name: Build ${{ matrix.model }}
-        run: cd  src  &&  make  clean  &&  make  -j$(nproc)
+        run: python3 src/build-scripts/hydrafw-revision.py  &&  cd  src  &&  make  clean  &&  make  -j$(nproc)
 
       - name: Archive ${{ matrix.model }} artifacts
         uses: actions/upload-artifact@v4

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,27 @@
 #!/usr/bin/env bash
 set -e
 
+set +e
+set -x
+
+echo "${GITHUB_CI_PR_SHA}"
+sha="`git  rev-parse  --short=8  HEAD`"
+tag="`git  tag  --points-at  ${sha}`"
+git  rev-parse  --symbolic-full-name  --short  HEAD
+date +%Y-%m-%d
+git  log  --pretty=oneline  v0.11..master
+git  log  --pretty=oneline  v0.11..master  |  wc -l
+git  log  --pretty=oneline  v0.11...master
+git  log  --pretty=oneline  v0.11...master  |  wc -l
+git describe --tags
+
+git  log  --pretty=oneline  origin/v0.11..origin/master
+git  log  --pretty=oneline  origin/v0.11..origin/master  |  wc -l
+
+echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`
+
+set -e
+
 # This script is used to enroll toolchain with GitHub Actions for CI/CD purposes
 # But this script can be used as reference to install recommended toolchain for building hydrafw.dfu locally as well
 
@@ -18,18 +39,3 @@ tar  xvjf  "${TARBALL}"
 
 echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
 
-set +e
-set -x
-
-echo "${GITHUB_CI_PR_SHA}"
-sha="`git  rev-parse  --short=8  HEAD`"
-tag="`git  tag  --points-at  ${sha}`"
-git  rev-parse  --symbolic-full-name  --short  HEAD
-date +%Y-%m-%d
-git  log  --pretty=oneline  v0.11..master
-git  log  --pretty=oneline  v0.11..master  |  wc -l
-git  log  --pretty=oneline  v0.11...master
-git  log  --pretty=oneline  v0.11...master  |  wc -l
-git describe --tags
-
-echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -28,6 +28,8 @@ git  rev-parse  --symbolic-full-name  --short  HEAD
 date +%Y-%m-%d
 git  log  --pretty=oneline  v0.11..master
 git  log  --pretty=oneline  v0.11..master  |  wc -l
+git  log  --pretty=oneline  v0.11...master
+git  log  --pretty=oneline  v0.11...master  |  wc -l
 git describe --tags
 
 echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -26,4 +26,8 @@ sha="`git  rev-parse  --short=8  HEAD`"
 tag="`git  tag  --points-at  ${sha}`"
 git  rev-parse  --symbolic-full-name  --short  HEAD
 date +%Y-%m-%d
+git  log  --pretty=oneline  v0.11..master
+git  log  --pretty=oneline  v0.11..master  |  wc -l
+git describe --tags
 
+echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -15,10 +15,11 @@ git  log  --pretty=oneline  v0.11...master
 git  log  --pretty=oneline  v0.11...master
 git describe --tags
 
-git  log  --pretty=oneline  origin/master
-
 git branch -a
 
+git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..origin/master
+git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..remotes/origin/master
+git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..hydrabus/master
 
 echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,44 +1,5 @@
 #!/usr/bin/env bash
-set -e
-
-set +e
-set -x
-
-git describe --tags  HEAD^1
-git describe --tags
-
-echo "-------------------------"
-
-echo "${GITHUB_CI_PR_SHA}"
-sha="`git  rev-parse  --short=8  HEAD`"
-tag="`git  tag  --points-at  ${sha}`"
-git  rev-parse  --symbolic-full-name  --short  HEAD
-date +%Y-%m-%d
-git  log  --pretty=oneline  v0.11..master
-git  log  --pretty=oneline  v0.11..master
-git  log  --pretty=oneline  v0.11...master
-git  log  --pretty=oneline  v0.11...master
-
-git branch -a
-
-fw_tag="`git describe --tags --abbrev=0`"
-fw_id="`git  rev-list  -n 1  ${fw_tag}`"
-
-git  log  --pretty=oneline  ${fw_id}..origin/master
-git  log  --pretty=oneline  ${fw_id}..origin/master | wc -l
-NUMERB22=git  log  --pretty=oneline  ${fw_id}..origin/master | wc -l
-
-echo "====="
-echo "${NUMBER22}"
-echo "====="
-
-git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..origin/master
-git  log  --pretty=oneline  v0.11..origin/master
-git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..remotes/origin/master
-git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..hydrabus/master
-
-echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`
-
+#set -x
 set -e
 
 # This script is used to enroll toolchain with GitHub Actions for CI/CD purposes

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
+# This script is used to enroll toolchain with GitHub Actions for CI/CD purposes
+# But this script can be used as reference to install recommended toolchain for building hydrafw.dfu locally as well
+
 MD5SUM=8a4a74872830f80c788c944877d3ad8c
 TARBALL=gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2
 TARDIR=gcc-arm-none-eabi-4_9-2015q3

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -10,13 +10,15 @@ tag="`git  tag  --points-at  ${sha}`"
 git  rev-parse  --symbolic-full-name  --short  HEAD
 date +%Y-%m-%d
 git  log  --pretty=oneline  v0.11..master
-git  log  --pretty=oneline  v0.11..master  |  wc -l
+git  log  --pretty=oneline  v0.11..master
 git  log  --pretty=oneline  v0.11...master
-git  log  --pretty=oneline  v0.11...master  |  wc -l
+git  log  --pretty=oneline  v0.11...master
 git describe --tags
 
-git  log  --pretty=oneline  origin/v0.11..origin/master
-git  log  --pretty=oneline  origin/v0.11..origin/master  |  wc -l
+git  log  --pretty=oneline  origin/master
+
+git branch -a
+
 
 echo `git describe --tags --abbrev=0`-`git  log  --pretty=oneline  v0.11..master  |  wc -l`
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -14,8 +14,10 @@ CURDIR="$(pwd)"
 echo  "${MD5SUM} ${TARBALL}"  >  md5.txt
 wget  "${LINK}"
 md5sum  -c  md5.txt
+rm  md5.txt
 
 tar  xvjf  "${TARBALL}"
+rm  "${TARBALL}"
 
 echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -17,7 +17,19 @@ git describe --tags
 
 git branch -a
 
+fw_tag="`git describe --tags --abbrev=0`"
+fw_id="`git  rev-list  -n 1  ${fw_tag}`"
+
+git  log  --pretty=oneline  ${fw_id}..origin/master
+git  log  --pretty=oneline  ${fw_id}..origin/master | wc -l
+NUMERB22=git  log  --pretty=oneline  ${fw_id}..origin/master | wc -l
+
+echo "====="
+echo "${NUMBER22}"
+echo "====="
+
 git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..origin/master
+git  log  --pretty=oneline  v0.11..origin/master
 git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..remotes/origin/master
 git  log  --pretty=oneline  d6d65865716adc1419cc89e59d05f99dc99f89a9..hydrabus/master
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -19,5 +19,15 @@ rm  md5.txt
 tar  xvjf  "${TARBALL}"
 rm  "${TARBALL}"
 
-echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
+if [ -n "${GITHUB_CI_PR_SHA}" ]; then
+	# This is for GitHub Actions CI/CD tooling only
+	echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
+else
+	# And this is for local install
+	echo ""
+	echo  "Add a line like"
+	echo "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\""
+	echo "to your ~/.profile and/or ~/.bashrc and run the line to enable toolchain as default one for arm-none-eabi-* target"
+	echo ""
+fi;
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -e
+
+MD5SUM=8a4a74872830f80c788c944877d3ad8c
+TARBALL=gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2
+TARDIR=gcc-arm-none-eabi-4_9-2015q3
+LINK=https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/"${TARBALL}"
+CURDIR="$(pwd)"
+
+echo  "${MD5SUM} ${TARBALL}"  >  md5.txt
+wget  "${LINK}"
+md5sum  -c  md5.txt
+
+tar  xvjf  "${TARBALL}"
+
+echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
+

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -4,6 +4,11 @@ set -e
 set +e
 set -x
 
+git describe --tags  HEAD^1
+git describe --tags
+
+echo "-------------------------"
+
 echo "${GITHUB_CI_PR_SHA}"
 sha="`git  rev-parse  --short=8  HEAD`"
 tag="`git  tag  --points-at  ${sha}`"
@@ -13,7 +18,6 @@ git  log  --pretty=oneline  v0.11..master
 git  log  --pretty=oneline  v0.11..master
 git  log  --pretty=oneline  v0.11...master
 git  log  --pretty=oneline  v0.11...master
-git describe --tags
 
 git branch -a
 

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -18,3 +18,12 @@ tar  xvjf  "${TARBALL}"
 
 echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
 
+set +e
+set -x
+
+echo "${GITHUB_CI_PR_SHA}"
+sha="`git  rev-parse  --short=8  HEAD`"
+tag="`git  tag  --points-at  ${sha}`"
+git  rev-parse  --symbolic-full-name  --short  HEAD
+date +%Y-%m-%d
+

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -7,4 +7,6 @@ r = re.compile("v(\d+\.\d+).*")
 
 git=Repo(search_parent_directories=True).git
 version = git.describe(tags=True,always=True,dirty=True,long=True)
+print("VERSION:", version)
+print("SEARCH:", r.search(version))
 print(r.search(version).group(1))

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -5,12 +5,9 @@ import re
 
 r = re.compile("v(\d+\.\d+).*")
 
-try:
-    git=Repo(search_parent_directories=True).git
-    version = git.describe(tags=True,always=True,dirty=True,long=True)
-    if r.search(version):
-        print(r.search(version).group(1))
-    else:
-        print("0.0")
-except InvalidGitRepositoryError:
+git=Repo(search_parent_directories=True).git
+version = git.describe(tags=True,always=True,dirty=True,long=True)
+if r.search(version):
+    print(r.search(version).group(1))
+else:
     print("0.0")

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -12,5 +12,5 @@ try:
         print(r.search(version).group(1))
     else:
         print("0.0")
-except git.exc.InvalidGitRepositoryError:
+except InvalidGitRepositoryError:
     print("0.0")

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -5,9 +5,12 @@ import re
 
 r = re.compile("v(\d+\.\d+).*")
 
-git=Repo(search_parent_directories=True).git
-version = git.describe(tags=True,always=True,dirty=True,long=True)
-if r.search(version):
-    print(r.search(version).group(1))
-else:
+try:
+    git=Repo(search_parent_directories=True).git
+    version = git.describe(tags=True,always=True,dirty=True,long=True)
+    if r.search(version):
+        print(r.search(version).group(1))
+    else:
+        print("0.0")
+except git.exc.InvalidGitRepositoryError:
     print("0.0")

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -10,4 +10,4 @@ version = git.describe(tags=True,always=True,dirty=True,long=True)
 if r.search(version):
     print(r.search(version).group(1))
 else:
-    print(version)
+    print("0.0")

--- a/src/build-scripts/hydrafw-revision.py
+++ b/src/build-scripts/hydrafw-revision.py
@@ -7,6 +7,7 @@ r = re.compile("v(\d+\.\d+).*")
 
 git=Repo(search_parent_directories=True).git
 version = git.describe(tags=True,always=True,dirty=True,long=True)
-print("VERSION:", version)
-print("SEARCH:", r.search(version))
-print(r.search(version).group(1))
+if r.search(version):
+    print(r.search(version).group(1))
+else:
+    print(version)

--- a/src/build-scripts/hydrafw-version.py
+++ b/src/build-scripts/hydrafw-version.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import sys
+import os
 from optparse import OptionParser
 from datetime import *
 from git import *
@@ -14,7 +15,12 @@ parser = OptionParser(usage=usage)
 if len(args)==1:
   sys.stdout = open(args[0], 'w')
   git=Repo(search_parent_directories=True).git
-  print('#define HYDRAFW_GIT_TAG "' + git.describe(tags=True,always=True,dirty=True,long=True) + '"')
+  vermagic=git.describe(tags=True,always=True,dirty=True,long=True)
+  if os.environ.get("GITHUB_CI_PR_SHA", "") != "":
+    sha_id=os.environ["GITHUB_CI_PR_SHA"][:7]
+    print('#define HYDRAFW_GIT_TAG "' + re.sub('-g.*$', '-g' + sha_id, vermagic) + '"')
+  else:
+    print('#define HYDRAFW_GIT_TAG "' + vermagic + '"')
   print('#define HYDRAFW_CHECKIN_DATE "' + git.show(['-s', '--pretty=format:%ai']).partition(' ')[0] + '"')
 else:
   parser.print_help()

--- a/src/build-scripts/hydrafw-version.py
+++ b/src/build-scripts/hydrafw-version.py
@@ -2,6 +2,7 @@
 
 import sys
 import os
+import re
 from optparse import OptionParser
 from datetime import *
 from git import *

--- a/src/build-scripts/hydrafw-version.py
+++ b/src/build-scripts/hydrafw-version.py
@@ -18,9 +18,11 @@ if len(args)==1:
   git=Repo(search_parent_directories=True).git
   vermagic=git.describe(tags=True,always=True,dirty=True,long=True)
   if os.environ.get("GITHUB_CI_PR_SHA", "") != "":
+    # if GITHUB_CI_PR_SHA is set, then it's GitHub Actions build, so workaround to set a valid tag is required
     sha_id=os.environ["GITHUB_CI_PR_SHA"][:7]
     print('#define HYDRAFW_GIT_TAG "' + re.sub('-g.*$', '-g' + sha_id, vermagic) + '"')
   else:
+    # If it's local build, then set "normal" tag
     print('#define HYDRAFW_GIT_TAG "' + vermagic + '"')
   print('#define HYDRAFW_CHECKIN_DATE "' + git.show(['-s', '--pretty=format:%ai']).partition(' ')[0] + '"')
 else:


### PR DESCRIPTION
TL;DR: utilize GitHub capabilities to make builds on every commit and on every pull-request.

Hello. I'm a bit surprised that this haven't been done yet. So I decided to take some liberty to help with that. There may be a lot of room for improvements in the future but this is _work-able_ proof-of-concept which can be merged & adopted as is currently in my humble opinion. However, to fully integrate `push.yml` into `hydrafw` github project, admins may need to set some additional settings _somewhere_ in _Settings_ of the project using GitHub web interface manually.

The benefits are:
- always be sure that current code at least _build-able_;
- without need to enroll local devel environment, advanced users who just will need `dfu-util`, always be able to get the latest fresh build from main branch;

Partially this overlaps with #132 and I can't promise anything but every time I have some free time I try to keep contributing around these CI/CD improvements as well.

Now, to technical details so everyone who is interested & curious could be on the same page. Basically, `push.yml` here is the most minimal declarative file which tells _GitHub_ to start _Ubuntu_ `22.04` VM, then to start _Debian_ `oldstable` container inside, install toolchain packages, build `hydrafw.dfu` and upload it as `hydrafw.dfu` artifact. The live _"demo"_ can be seen in my forked repo [here](https://github.com/ia/hydrafw/actions):
 - [overview](https://github.com/ia/hydrafw/actions)
 - [latest green build](https://github.com/ia/hydrafw/actions/runs/8401295543)
 - [artifact section](https://github.com/ia/hydrafw/actions/runs/8401295543#artifacts)
 - [direct link to `hydrafw.zip`](https://github.com/ia/hydrafw/actions/runs/8401295543/artifacts/1352346834)
 
 Now, why such "matreshka" with VMs/containers, you may ask. Well, _GitHub_ doesn't have _Debian_ `oldstable` to run it directly, but we can start it from VM which is available on _GitHub_. After tries & errors _Debian_ `oldstable` has been picked as [so far] the most suitable one, since:
 - it has `git` with fresh enough version to support `actions/checkout@v4` (it needs `git` > 2.17)
 - it has old enough `GCC` toolchain where _LTO_ for `ChibiOS` doesn't have [a strange issue](http://forum.chibios.org/viewtopic.php?t=5830) ([sample log from one of my builds](https://github.com/ia/hydrafw/actions/runs/8388352807/job/22972355589#step:8:202))
 
 If you have any other questions, just let me know.
 
Oh, and that tiny update for `python` script comes from specific behavior of _GitHub_ actions: on every checkout before build, _GitHub_ infrastructure doesn't make full valid `git checkout` but downloads source tree in detached state so getting meta information about repo and its status (tag, revision, sha, etc.) may be tricky because I saw that with other GitHub projects so for a while we set revision as `0.0` for _GitHub_ builds (which is default value) but it's even good in its own way because by that it will be the indicator that it is _the latest upstream mainline build_ but not a stable release.