### PR TITLE
push.yml/env.sh: set helper variable to indicate building on github explicitly

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,7 +35,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set git meta info
-        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"
+        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"  &&  echo "GITHUB_CI_CD=1" >> "${GITHUB_ENV}"
 
       - name: Install standalone reference GCC toolchain
         run: bash  scripts/env.sh

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -19,7 +19,7 @@ rm  md5.txt
 tar  xvjf  "${TARBALL}"
 rm  "${TARBALL}"
 
-if [ -n "${GITHUB_CI_PR_SHA}" ]; then
+if [ -n "${GITHUB_CI_PR_SHA}" ] || [ 1 -eq "${GITHUB_CI_CD}" ]; then
 	# This is for GitHub Actions CI/CD tooling only
 	echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
 else


### PR DESCRIPTION
Set additional variable in `push.yml` to explicitly indicate building on _GitHub_ regardless a kind/trigger for a build (PR, merge, etc.).

:crossed_fingers: _Hopefully_ it should fix #168 , but I'm afraid we won't be able to find this out for 100% without merging this fix first.

P.S. Please, take my apologies for this bloop.