### PR TITLE
Fix integer comparison error by ensuring GITHUB_CI_CD is defined

### DIFF
--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -19,6 +19,9 @@ rm  md5.txt
 tar  xvjf  "${TARBALL}"
 rm  "${TARBALL}"
 
+# Ensure GITHUB_CI_CD is set and is an integer, default to 0 if not set
+GITHUB_CI_CD="${GITHUB_CI_CD:-0}"
+
 if [ -n "${GITHUB_CI_PR_SHA}" ] || [ 1 -eq "${GITHUB_CI_CD}" ]; then
 	# This is for GitHub Actions CI/CD tooling only
 	echo  "export  PATH=\"${CURDIR}/${TARDIR}/bin\":\"\${PATH}\"" > build.env
@@ -30,4 +33,3 @@ else
 	echo "to your ~/.profile and/or ~/.bashrc and run the line to enable toolchain as default one for arm-none-eabi-* target"
 	echo ""
 fi;
-


### PR DESCRIPTION
This commit resolves the error encountered when GITHUB_CI_CD is unset or non-integer by defaulting it to 0.

```
./scripts/env.sh: line 22: [: : integer expression expected
```