### PR TITLE
Add support to HydraBus to support ST25TB Kameleon board in place of HydraNFC v1

### DIFF
--- a/.github/workflows/push-kameleon.yml
+++ b/.github/workflows/push-kameleon.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      HYDRANFC_KAMELEON_FLAVOR: 1
+      
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+          fetch-tags: true
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+          cache: 'pip' # caching pip dependencies
+
+      - run: pip install -r src/requirements.txt
+
+      - name: Set git meta info
+        run: echo "GITHUB_CI_PR_SHA=${{github.event.pull_request.head.sha}}" >> "${GITHUB_ENV}"  &&  echo "GITHUB_CI_CD=1" >> "${GITHUB_ENV}"
+
+      - name: Install standalone reference GCC toolchain
+        run: bash  scripts/env.sh
+
+      - name: Build src/build-scripts/hex2dfu
+        run: cd src/build-scripts && make clean all
+
+      - name: Build hydrafw-kameleon
+        run: source  build.env  &&  arm-none-eabi-gcc --version  &&  arm-none-eabi-gcc -print-search-dirs  &&  make  V=1  -j$(nproc)  -C src/
+
+      - name: Archive hydrafw-kameleon artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: hydrafw-kameleon
+          path: |
+            src/build/hydrafw.dfu
+            src/build/hydrafw.hex
+            src/build/hydrafw.elf
+          if-no-files-found: error

--- a/.github/workflows/push-kameleon.yml
+++ b/.github/workflows/push-kameleon.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI-KAMELEON
 
 on:
   push:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -45,6 +45,8 @@ jobs:
           name: hydrafw
           path: |
             src/build/hydrafw.dfu
+            src/build/hydrafw.hex
+            src/build/hydrafw.elf
           if-no-files-found: error
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,11 +13,16 @@ export STM32F4XX ?= 1
 export HYDRAFW_NFC ?= 1
 export HYDRAFW_DEBUG ?= 0
 export FW_REVISION := $(shell build-scripts/hydrafw-revision)
+export HYDRANFC_KAMELEON_FLAVOR ?= 0
 
 HYDRAFW_OPTS =
 
 ifeq ($(HYDRAFW_NFC),1)
 HYDRAFW_OPTS += -DHYDRANFC
+endif
+
+ifeq ($(HYDRANFC_KAMELEON_FLAVOR),1)
+HYDRAFW_OPTS += -DHYDRANFC_KAMELEON_FLAVOR
 endif
 
 # Compiler options here.

--- a/src/hydranfc/trf7970a/include/mcu.h
+++ b/src/hydranfc/trf7970a/include/mcu.h
@@ -93,9 +93,9 @@ limitations under the License.
 #undef K2_BUTTON
 #undef K3_BUTTON
 #undef K4_BUTTON
-#define K2_BUTTON 0
-#define K3_BUTTON 0
-#define K4_BUTTON 0
+#define K2_BUTTON 0 // K2 is not used (only led actions ?)
+#define K3_BUTTON K1_BUTTON // K3 is used in key/sniffing actions, but not K1, so we're using it in place
+#define K4_BUTTON 0 // K4 is used to stop sniffing, but the USER BUTTON can be used in place, so we don't deal with K4 [ if ( (K4_BUTTON) || (hydrabus_ubtn()) ) ]
 #endif
 
 /* LEDs D2/D3/D4/D5 Configured as Output */

--- a/src/hydranfc/trf7970a/include/mcu.h
+++ b/src/hydranfc/trf7970a/include/mcu.h
@@ -82,11 +82,21 @@ limitations under the License.
 #define LED2_OFF (palClearPad(GPIOB, 0))
 #define LED2_TOGGLE (palTogglePad(GPIOB, 0))
 
-/* USer Button K1/2/3/4 Configured as Input */
+/* User Button K1/2/3/4 Configured as Input */
 #define K1_BUTTON (palReadPad(GPIOB, 7))
 #define K2_BUTTON (palReadPad(GPIOB, 6))
 #define K3_BUTTON (palReadPad(GPIOB, 8))
 #define K4_BUTTON (palReadPad(GPIOB, 9))
+
+/* Only one K1 Button on Kameleon board */
+#if defined(HYDRANFC_KAMELEON_FLAVOR)
+#undef K2_BUTTON
+#undef K3_BUTTON
+#undef K4_BUTTON
+#define K2_BUTTON 0
+#define K3_BUTTON 0
+#define K4_BUTTON 0
+#endif
 
 /* LEDs D2/D3/D4/D5 Configured as Output */
 #define D2_ON  (palSetPad(GPIOB, 0))


### PR DESCRIPTION
This pull request adapt:

- `Makefile` to support a build env variable `HYDRANFC_KAMELEON_FLAVOR`, when set to `1` it builds a special version of `hydrafw` supporting ST25TB Kameleon board
- HydraNFC's `mcu.h` to adapt K2/K3/K4 buttons (not on ST25TB Kameleon board - we needs leds !)
  -  K2 and K4 are not really used, and K3 is remapped to use K1
- CI Build, to support a special action for this flavor
- CI Build, to also collect `.hex` and `.elf` as artefact (not only `.dfu`)